### PR TITLE
Map pipeline TODO anchors to active roadmap issues

### DIFF
--- a/src/story_gen/core/dashboard_views.py
+++ b/src/story_gen/core/dashboard_views.py
@@ -310,7 +310,7 @@ def _build_graph(
 
     theme_ids = [theme.theme_id for theme in document.theme_signals]
     beat_ids = [beat.beat_id for beat in document.story_beats]
-    # TODO(#1007): Replace dense theme->beat linking with evidence-driven graph edges.
+    # TODO(#9): Replace dense theme->beat linking with evidence-driven graph edges.
     for theme_id in theme_ids:
         for beat_id in beat_ids:
             edges.append(

--- a/src/story_gen/core/language_translation.py
+++ b/src/story_gen/core/language_translation.py
@@ -34,7 +34,7 @@ _FRENCH_MARKERS: Final[set[str]] = {
 }
 
 _SPANISH_TO_ENGLISH: Final[dict[str, str]] = {
-    # TODO(#1002): Replace toy token map with model-backed translation service.
+    # TODO(#3): Replace toy token map with model-backed translation service.
     "historia": "story",
     "familia": "family",
     "conflicto": "conflict",
@@ -76,7 +76,7 @@ class SegmentAlignment:
 
 def detect_language(text: str) -> LanguageDetectionResult:
     """Detect language from lightweight lexical markers."""
-    # TODO(#1003): Upgrade from lexical/script heuristics to a robust language-id model.
+    # TODO(#3): Upgrade from lexical/script heuristics to a robust language-id model.
     japanese_chars = len(_JAPANESE_SCRIPT.findall(text))
     latin_chars = len(_LATIN_LETTER.findall(text))
     if japanese_chars >= 4 and japanese_chars >= latin_chars:
@@ -117,7 +117,7 @@ def translate_segments(
     target_language: str = "en",
 ) -> tuple[list[RawSegment], list[SegmentAlignment], str]:
     """Detect and translate segments into target language when needed."""
-    # TODO(#1004): Add external translation provider path with retries and circuit-breakers.
+    # TODO(#3): Add external translation provider path with retries and circuit-breakers.
     translated_segments: list[RawSegment] = []
     alignments: list[SegmentAlignment] = []
     detected_languages: list[str] = []

--- a/src/story_gen/core/story_extraction.py
+++ b/src/story_gen/core/story_extraction.py
@@ -24,7 +24,7 @@ def extract_events_and_entities(
     segments: list[RawSegment],
 ) -> tuple[list[ExtractedEvent], list[EntityMention]]:
     """Extract event and entity artifacts from normalized story segments."""
-    # TODO(#1005): Replace regex extractor with model-backed event/entity extraction.
+    # TODO(#5): Replace regex extractor with model-backed event/entity extraction.
     validate_extraction_input(segments)
     events: list[ExtractedEvent] = []
     entities_by_name: dict[str, list[str]] = defaultdict(list)

--- a/src/story_gen/core/theme_arc_tracking.py
+++ b/src/story_gen/core/theme_arc_tracking.py
@@ -19,7 +19,7 @@ from story_gen.core.story_schema import (
 )
 
 _THEME_KEYWORDS: dict[str, tuple[str, ...]] = {
-    # TODO(#1001): Replace keyword-based tagging with model-backed theme extraction.
+    # TODO(#6): Replace keyword-based tagging with model-backed theme extraction.
     "memory": ("memory", "remember", "archive", "history"),
     "conflict": ("fight", "conflict", "war", "battle"),
     "identity": ("identity", "name", "self", "origin"),

--- a/src/story_gen/core/timeline_composer.py
+++ b/src/story_gen/core/timeline_composer.py
@@ -87,7 +87,7 @@ def compose_timeline(
 
 
 def _stage_for_order(order: int, total: int) -> StoryStage:
-    # TODO(#1006): Derive event stage from beat linkage instead of order-ratio heuristic.
+    # TODO(#7): Derive event stage from beat linkage instead of order-ratio heuristic.
     if total <= 1:
         return "setup"
     ratio = order / total


### PR DESCRIPTION
## Summary
Small housekeeping pass: I mapped existing TODO anchors to the live roadmap issues so we can track them properly.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/3
- https://github.com/ringxworld/story_generator/issues/5
- https://github.com/ringxworld/story_generator/issues/6
- https://github.com/ringxworld/story_generator/issues/7
- https://github.com/ringxworld/story_generator/issues/9

## Motivation / Context
We had TODO references like #1001 to #1007 that did not map to real issues. This change links those stubs to the current milestone backlog so future work is traceable.

## What Changed
- Linked translation TODOs to https://github.com/ringxworld/story_generator/issues/3.
- Linked extraction TODO to https://github.com/ringxworld/story_generator/issues/5.
- Linked theme/arc TODO to https://github.com/ringxworld/story_generator/issues/6.
- Linked timeline TODO to https://github.com/ringxworld/story_generator/issues/7.
- Linked graph TODO to https://github.com/ringxworld/story_generator/issues/9.

## Tradeoffs and Risks
- No runtime behavior changes.
- Future renumbering would require updating these links.

## How This Was Tested
- Unit tests added or updated: none (metadata only).
- Manual test cases run: `rg TODO\(# src/story_gen/core`.
- Inputs used to validate behavior: source files in `src/story_gen/core`.
- Not tested (if any): runtime behavior (no change).

## Follow-ups / Future Work
- Implement the linked issues on dedicated branches.