### PR TITLE
Make PRs link issues explicitly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,12 @@
 Briefly describe what this change does and why it exists.
 Focus on intent and effect, not implementation details.
 
+## Linked Issues
+
+Use full URLs so GitHub links them automatically.
+
+- https://github.com/ringxworld/story_generator/issues/<id>
+
 ## Motivation / Context
 
 Why this change is needed now.

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           required_sections=(
             "## Summary"
+            "## Linked Issues"
             "## Motivation / Context"
             "## What Changed"
             "## Tradeoffs and Risks"
@@ -32,5 +33,10 @@ jobs:
 
           if [ "$missing" -ne 0 ]; then
             echo "PR template requirements not satisfied."
+            exit 1
+          fi
+
+          if ! grep -Eq "https://github.com/ringxworld/story_generator/issues/[0-9]+" <<<"$PR_BODY"; then
+            echo "Missing linked issue URL."
             exit 1
           fi

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -141,6 +141,7 @@ def test_precommit_enforces_commit_and_push_quality() -> None:
 def test_pr_template_contains_required_sections() -> None:
     template = _read(".github/pull_request_template.md")
     assert "## Summary" in template
+    assert "## Linked Issues" in template
     assert "## Motivation / Context" in template
     assert "## What Changed" in template
     assert "## Tradeoffs and Risks" in template
@@ -153,11 +154,13 @@ def test_pr_template_workflow_exists_and_checks_sections() -> None:
     assert "name: PR Template Check" in workflow
     assert "name: pr-template" in workflow
     assert "## Summary" in workflow
+    assert "## Linked Issues" in workflow
     assert "## Motivation / Context" in workflow
     assert "## What Changed" in workflow
     assert "## Tradeoffs and Risks" in workflow
     assert "## How This Was Tested" in workflow
     assert "## Follow-ups / Future Work" in workflow
+    assert "story_generator/issues" in workflow
 
 
 def test_pyproject_exposes_story_collection_entrypoints() -> None:


### PR DESCRIPTION
## Summary
Tightens PR text so issue links are explicit and human-auditable.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/16

## Motivation / Context
We want PRs to read like a human was in the loop and to link issues directly instead of leaving bare numbers in the body.

## What Changed
- Added a `Linked Issues` section to the PR template.
- Enforced presence of a real issue URL in the PR template check.
- Added contract-test checks for the new section and URL requirement.

## Tradeoffs and Risks
- PRs without linked issues now fail the template check.
- This increases up-front PR discipline but prevents orphaned work.

## How This Was Tested
- Unit tests added or updated: `tests/test_project_contracts.py`.
- Manual test cases run: `uv run pre-commit run --files ...`.
- Inputs used to validate behavior: updated template + workflow file.
- Not tested (if any): runtime behavior (no change).

## Follow-ups / Future Work
- Update any open PRs to include a `Linked Issues` section if needed.