### PR TITLE
Add human diction rules for issues and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,13 @@ After each completed prompt:
 2. validate
 3. commit
 4. push to `origin/main`
+
+## 8. Human-Facing Wording for Issues and PRs
+
+When writing issue or PR text:
+
+- Use human, specific language over boilerplate.
+- Prefer concrete sentences about intent and impact.
+- Avoid templated phrases like "This change does X" when a more natural sentence works.
+- Link issues with full URLs, not just `#123`.
+- State tradeoffs and test coverage explicitly, without hedging.


### PR DESCRIPTION
## Summary
Adds guidance so issue and PR text reads like a person wrote it and links issues explicitly.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/18

## Motivation / Context
We want audit-friendly issue/PR text that is clear, direct, and not template-heavy.

## What Changed
- Added human wording rules for issue/PR text in `AGENTS.md`.
- Required full issue URLs in issue/PR references.

## Tradeoffs and Risks
- This is a policy change only; it doesn’t affect runtime behavior.

## How This Was Tested
- Unit tests added or updated: none (doc-only change).
- Manual test cases run: `uv run pre-commit run --files AGENTS.md`.
- Inputs used to validate behavior: `AGENTS.md`.
- Not tested (if any): runtime behavior.

## Follow-ups / Future Work
- Apply the guidance to new issues and PRs as they are opened.