### PR TITLE
Add human-style PR review guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,12 @@ When writing issue or PR text:
 - Avoid templated phrases like "This change does X" when a more natural sentence works.
 - Link issues with full URLs, not just `#123`.
 - State tradeoffs and test coverage explicitly, without hedging.
+
+## 9. Human-Facing PR Reviews
+
+When commenting or reviewing pull requests:
+
+- Use normal paragraph spacing and complete sentences.
+- Lead with the most important finding, then explain why it matters.
+- Avoid robotic checklists unless the author asked for one.
+- Call out missing tests and edge cases in plain language.


### PR DESCRIPTION
## Summary
Adds explicit guidance so PR review comments read like a human wrote them.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/20

## Motivation / Context
The current review comments look templated and awkwardly spaced. This adds clear rules for more natural phrasing.

## What Changed
- Added a new section in `AGENTS.md` that defines tone and spacing for PR reviews.

## Tradeoffs and Risks
- Policy-only change with no runtime impact.

## How This Was Tested
- Unit tests added or updated: none (doc-only change).
- Manual test cases run: `uv run pre-commit run --files AGENTS.md`.
- Inputs used to validate behavior: `AGENTS.md`.
- Not tested (if any): runtime behavior.

## Follow-ups / Future Work
- Apply these rules in upcoming PR reviews.