### PR TITLE
Allow compact PR mode and default reviewer assignment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,19 @@
-## Summary
+Pick one mode and delete the other before submitting.
+
+## Full Mode (feature/risky work)
+
+### Summary
 
 Briefly describe what this change does and why it exists.
 Focus on intent and effect, not implementation details.
 
-## Linked Issues
+### Linked Issues
 
 Use full URLs so GitHub links them automatically.
 
 - https://github.com/ringxworld/story_generator/issues/<id>
 
-## Motivation / Context
+### Motivation / Context
 
 Why this change is needed now.
 
@@ -17,7 +21,7 @@ Why this change is needed now.
 - What assumption is being corrected
 - What new capability this unlocks
 
-## What Changed
+### What Changed
 
 Concrete, reviewable bullets.
 
@@ -25,7 +29,7 @@ Concrete, reviewable bullets.
 - Removed:
 - Refactored:
 
-## Tradeoffs and Risks
+### Tradeoffs and Risks
 
 Call out anything non-obvious.
 
@@ -34,7 +38,7 @@ Call out anything non-obvious.
 - Edge cases that still exist:
 - Things deliberately left out:
 
-## How This Was Tested
+### How This Was Tested
 
 Be honest and specific.
 
@@ -43,10 +47,28 @@ Be honest and specific.
 - Inputs used to validate behavior:
 - Not tested (if any):
 
-## Follow-ups / Future Work
+### Follow-ups / Future Work
 
 Optional. Only include if relevant.
 
 - Cleanup opportunities:
 - Known gaps:
 - Ideas explicitly deferred:
+
+## Compact Mode (docs/chore/small scope)
+
+### Summary
+
+One short paragraph explaining intent and user impact.
+
+### Linked Issues
+
+- https://github.com/ringxworld/story_generator/issues/<id>
+
+### Change Notes
+
+What changed, why, and key tradeoffs in concise bullets.
+
+### Validation
+
+What you tested, what you did not test, and why.

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -13,26 +13,53 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          required_sections=(
-            "## Summary"
-            "## Linked Issues"
-            "## Motivation / Context"
-            "## What Changed"
-            "## Tradeoffs and Risks"
-            "## How This Was Tested"
-            "## Follow-ups / Future Work"
-          )
+          has_heading() {
+            local heading="$1"
+            grep -Eiq "^[[:space:]]*#{2,3}[[:space:]]*${heading}[[:space:]]*$" <<<"$PR_BODY"
+          }
 
-          missing=0
-          for section in "${required_sections[@]}"; do
-            if ! grep -Fq "$section" <<<"$PR_BODY"; then
-              echo "Missing required PR section: $section"
-              missing=1
+          # Always required for traceability.
+          if ! has_heading "Summary"; then
+            echo "Missing required PR section: Summary"
+            exit 1
+          fi
+          if ! has_heading "Linked Issues"; then
+            echo "Missing required PR section: Linked Issues"
+            exit 1
+          fi
+
+          # Full mode supports larger/riskier changes.
+          full_sections=(
+            "Motivation / Context"
+            "What Changed"
+            "Tradeoffs and Risks"
+            "How This Was Tested"
+            "Follow-ups / Future Work"
+          )
+          full_missing=0
+          for section in "${full_sections[@]}"; do
+            if ! has_heading "$section"; then
+              full_missing=1
+              break
             fi
           done
 
-          if [ "$missing" -ne 0 ]; then
+          # Compact mode supports docs/chore/small diffs.
+          compact_sections=(
+            "Change Notes"
+            "Validation"
+          )
+          compact_missing=0
+          for section in "${compact_sections[@]}"; do
+            if ! has_heading "$section"; then
+              compact_missing=1
+              break
+            fi
+          done
+
+          if [ "$full_missing" -ne 0 ] && [ "$compact_missing" -ne 0 ]; then
             echo "PR template requirements not satisfied."
+            echo "Provide either full mode sections or compact mode sections."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,12 @@ When commenting or reviewing pull requests:
 - Lead with the most important finding, then explain why it matters.
 - Avoid robotic checklists unless the author asked for one.
 - Call out missing tests and edge cases in plain language.
+
+## 10. PR Body Flexibility and Reviewer Assignment
+
+When creating PRs:
+
+- Use the full PR structure for large or risky work.
+- Use a compact PR structure for docs/chore/small-scope work when context can be concise.
+- Always include `Summary` and `Linked Issues`.
+- Request reviewer `ringxworld` by default (or assign as assignee when self-review is blocked).

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -29,6 +29,12 @@ One-command flow:
 make pr-auto
 ```
 
+Default reviewer behavior:
+
+- `tools/pr_flow.py` requests reviewer `ringxworld` by default.
+- Override with `PR_DEFAULT_REVIEWER=<login>` or `--reviewer <login>`.
+- If GitHub blocks self-review requests, the same login is added as PR assignee.
+
 ## Pull request defaults in this repo
 
 - PR template: `.github/pull_request_template.md`
@@ -48,9 +54,7 @@ make pr-auto
   - `pages`
   - `pr-template`
 - Required PR body sections are validated by workflow:
-  - `Summary`
-  - `Motivation / Context`
-  - `What Changed`
-  - `Tradeoffs and Risks`
-  - `How This Was Tested`
-  - `Follow-ups / Future Work`
+  - Always required: `Summary`, `Linked Issues`
+  - Choose one mode:
+  - Full mode: `Motivation / Context`, `What Changed`, `Tradeoffs and Risks`, `How This Was Tested`, `Follow-ups / Future Work`
+  - Compact mode: `Change Notes`, `Validation`

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -140,26 +140,33 @@ def test_precommit_enforces_commit_and_push_quality() -> None:
 
 def test_pr_template_contains_required_sections() -> None:
     template = _read(".github/pull_request_template.md")
-    assert "## Summary" in template
-    assert "## Linked Issues" in template
-    assert "## Motivation / Context" in template
-    assert "## What Changed" in template
-    assert "## Tradeoffs and Risks" in template
-    assert "## How This Was Tested" in template
-    assert "## Follow-ups / Future Work" in template
+    assert "## Full Mode (feature/risky work)" in template
+    assert "## Compact Mode (docs/chore/small scope)" in template
+    assert "### Summary" in template
+    assert "### Linked Issues" in template
+    assert "### Motivation / Context" in template
+    assert "### What Changed" in template
+    assert "### Tradeoffs and Risks" in template
+    assert "### How This Was Tested" in template
+    assert "### Follow-ups / Future Work" in template
+    assert "### Change Notes" in template
+    assert "### Validation" in template
 
 
 def test_pr_template_workflow_exists_and_checks_sections() -> None:
     workflow = _read(".github/workflows/pr-template-check.yml")
     assert "name: PR Template Check" in workflow
     assert "name: pr-template" in workflow
-    assert "## Summary" in workflow
-    assert "## Linked Issues" in workflow
-    assert "## Motivation / Context" in workflow
-    assert "## What Changed" in workflow
-    assert "## Tradeoffs and Risks" in workflow
-    assert "## How This Was Tested" in workflow
-    assert "## Follow-ups / Future Work" in workflow
+    assert 'has_heading "Summary"' in workflow
+    assert 'has_heading "Linked Issues"' in workflow
+    assert '"Motivation / Context"' in workflow
+    assert '"What Changed"' in workflow
+    assert '"Tradeoffs and Risks"' in workflow
+    assert '"How This Was Tested"' in workflow
+    assert '"Follow-ups / Future Work"' in workflow
+    assert '"Change Notes"' in workflow
+    assert '"Validation"' in workflow
+    assert "Provide either full mode sections or compact mode sections." in workflow
     assert "story_generator/issues" in workflow
 
 
@@ -389,6 +396,9 @@ def test_pr_flow_supports_explicit_or_fallback_gh_binary() -> None:
     script = _read("tools/pr_flow.py")
     assert "GH_BIN" in script
     assert "GitHub CLI\\gh.exe" in script
+    assert "PR_DEFAULT_REVIEWER" in script
+    assert "--add-reviewer" in script
+    assert "--add-assignee" in script
     assert (ROOT / "web" / "public" / "icons" / "icon-16.png").exists()
     assert (ROOT / "web" / "public" / "icons" / "icon-32.png").exists()
     assert (ROOT / "web" / "public" / "icons" / "icon-192.png").exists()


### PR DESCRIPTION
## Summary
This updates PR workflow so small changes can use a compact writeup and PR creation auto-requests the default maintainer reviewer.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/22

## Change Notes
- Added dual-mode PR template support: full mode for large/risky work and compact mode for docs/chore/small-scope work.
- Updated `pr-template` workflow to require `Summary` and `Linked Issues`, then accept either the full section set or compact section set.
- Updated `tools/pr_flow.py` to request reviewer `ringxworld` by default (configurable via `PR_DEFAULT_REVIEWER` or `--reviewer`).
- Added fallback to assignee when GitHub blocks self-review requests.
- Updated collaboration and agent guidance to reflect compact PR mode and reviewer behavior.
- Updated repository contract tests to cover new template/check logic and reviewer flags.

## Validation
- `uv run pre-commit run --files .github/pull_request_template.md .github/workflows/pr-template-check.yml AGENTS.md docs/github_collaboration.md tests/test_project_contracts.py tools/pr_flow.py`
- `uv run pytest -o addopts= tests/test_project_contracts.py`
- Manual check: opened PR with `uv run python tools/pr_flow.py open --base develop --title "Allow compact PR mode and default reviewer assignment"` and verified fallback assignee behavior when self-review request is blocked.