### PR TITLE
Document project board polish as an explicit directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,12 @@ When commenting or reviewing pull requests:
 - Lead with the most important finding, then explain why it matters.
 - Avoid robotic checklists unless the author asked for one.
 - Call out missing tests and edge cases in plain language.
+
+## 10. Project Board Hygiene
+
+Treat the GitHub Projects page as a first-class planning surface:
+
+- Keep project names, view names, and field names human-readable.
+- Keep issue titles concise so board scans are clear.
+- Keep `Status`, `Track`, and `Priority Band` up to date as work moves.
+- Avoid placeholder names (for example: `View 1`) once a board is active.

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -37,6 +37,17 @@ make pr-auto
   - config: `.github/labeler.yml`
   - workflow: `.github/workflows/pr-labeler.yml`
 
+## Project board directives
+
+- Keep the roadmap board polished and readable.
+- Use human names for board/title/view/fields (replace placeholders like `View 1`).
+- Keep issue titles concise for quick scan value.
+- Keep board metadata current on active items:
+  - `Status`
+  - `Track`
+  - `Priority Band`
+- Move cards as soon as implementation state changes, not at end-of-day.
+
 ## Enforced merge policy
 
 - Pull requests are required for `develop` and `main`.
@@ -49,8 +60,7 @@ make pr-auto
   - `pr-template`
 - Required PR body sections are validated by workflow:
   - `Summary`
-  - `Motivation / Context`
+  - `Linked Issues`
   - `What Changed`
-  - `Tradeoffs and Risks`
+  - `Tasks Completed`
   - `How This Was Tested`
-  - `Follow-ups / Future Work`


### PR DESCRIPTION
﻿## Summary
Adds an explicit directive that the GitHub Projects page must be kept polished and readable, and aligns collaboration docs with that expectation.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/28

## Motivation / Context
The board is now part of how work is planned and reviewed. Keeping it clean and human-readable should be an explicit repo rule, not an implicit preference.

## What Changed
- Added `Project Board Hygiene` directives to `AGENTS.md`.
- Added a `Project board directives` section to `docs/github_collaboration.md`.
- Updated collaboration docs to reflect the lean PR section policy currently being adopted.

## Tradeoffs and Risks
- PR section wording in docs may briefly lead workflow enforcement until the PR template-check update branch is merged.

## How This Was Tested
- Ran `uv run pre-commit run --files AGENTS.md docs/github_collaboration.md`.

## Follow-ups / Future Work
- Merge PR #29 so docs and workflow enforcement are fully consistent on required PR sections.
