### PR TITLE
Support full and compact PR template modes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,19 @@ Use full URLs so GitHub links them automatically.
 
 - https://github.com/ringxworld/story_generator/issues/<id>
 
-## What Changed
+## Full Mode (Larger/Riskier Change)
+
+Use this mode for larger, cross-cutting, or higher-risk PRs.
+
+### Motivation / Context
+
+Why this change is needed now.
+
+- What was broken, unclear, or fragile
+- What assumption is being corrected
+- What new capability this unlocks
+
+### What Changed
 
 Concrete, reviewable bullets.
 
@@ -17,14 +29,16 @@ Concrete, reviewable bullets.
 - Changed:
 - Removed:
 
-## Tasks Completed
+### Tradeoffs and Risks
 
-Mirror the concrete tasks finished in this PR. Checkboxes make review faster.
+Call out anything non-obvious.
 
-- [ ] Task completed:
-- [ ] Task completed:
+- Performance impacts:
+- Behavior changes:
+- Edge cases that still exist:
+- Things deliberately left out:
 
-## How This Was Tested
+### How This Was Tested
 
 Be honest and specific.
 
@@ -33,6 +47,23 @@ Be honest and specific.
 - Inputs used to validate behavior:
 - Not tested (if any):
 
-## Notes (Optional)
+### Follow-ups / Future Work (Optional)
 
-Use this for risk/tradeoffs/follow-ups only when it adds signal.
+- Cleanup opportunities:
+- Known gaps:
+- Ideas explicitly deferred:
+
+## Compact Mode (Small/Low-Risk Change)
+
+Use this mode for docs/chore/small-scope PRs.
+
+### Change Notes
+
+- What changed in plain language:
+- Why this small change matters:
+
+### Validation
+
+Be honest and specific.
+
+- Checks run (or reason skipped):

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -13,24 +13,54 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          required_sections=(
+          common_sections=(
             "## Summary"
             "## Linked Issues"
-            "## What Changed"
-            "## Tasks Completed"
-            "## How This Was Tested"
+          )
+
+          full_mode_sections=(
+            "### Motivation / Context"
+            "### What Changed"
+            "### Tradeoffs and Risks"
+            "### How This Was Tested"
+          )
+
+          compact_mode_sections=(
+            "### Change Notes"
+            "### Validation"
           )
 
           missing=0
-          for section in "${required_sections[@]}"; do
+          for section in "${common_sections[@]}"; do
             if ! grep -Fq "$section" <<<"$PR_BODY"; then
               echo "Missing required PR section: $section"
               missing=1
             fi
           done
 
+          has_full_mode=1
+          for section in "${full_mode_sections[@]}"; do
+            if ! grep -Fq "$section" <<<"$PR_BODY"; then
+              has_full_mode=0
+              break
+            fi
+          done
+
+          has_compact_mode=1
+          for section in "${compact_mode_sections[@]}"; do
+            if ! grep -Fq "$section" <<<"$PR_BODY"; then
+              has_compact_mode=0
+              break
+            fi
+          done
+
           if [ "$missing" -ne 0 ]; then
             echo "PR template requirements not satisfied."
+            exit 1
+          fi
+
+          if [ "$has_full_mode" -ne 1 ] && [ "$has_compact_mode" -ne 1 ]; then
+            echo "PR must include either full mode sections or compact mode sections."
             exit 1
           fi
 

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -74,6 +74,7 @@ Wiki URL:
 - Required PR body sections are validated by workflow:
   - `Summary`
   - `Linked Issues`
-  - `What Changed`
-  - `Tasks Completed`
-  - `How This Was Tested`
+  - full mode:
+  `Motivation / Context`, `What Changed`, `Tradeoffs and Risks`, `How This Was Tested`
+  - compact mode:
+  `Change Notes`, `Validation`

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -148,10 +148,14 @@ def test_pr_template_contains_required_sections() -> None:
     template = _read(".github/pull_request_template.md")
     assert "## Summary" in template
     assert "## Linked Issues" in template
-    assert "## What Changed" in template
-    assert "## Tasks Completed" in template
-    assert "## How This Was Tested" in template
-    assert "## Notes (Optional)" in template
+    assert "## Full Mode (Larger/Riskier Change)" in template
+    assert "### Motivation / Context" in template
+    assert "### What Changed" in template
+    assert "### Tradeoffs and Risks" in template
+    assert "### How This Was Tested" in template
+    assert "## Compact Mode (Small/Low-Risk Change)" in template
+    assert "### Change Notes" in template
+    assert "### Validation" in template
 
 
 def test_pr_template_workflow_exists_and_checks_sections() -> None:
@@ -160,9 +164,11 @@ def test_pr_template_workflow_exists_and_checks_sections() -> None:
     assert "name: pr-template" in workflow
     assert "## Summary" in workflow
     assert "## Linked Issues" in workflow
-    assert "## What Changed" in workflow
-    assert "## Tasks Completed" in workflow
-    assert "## How This Was Tested" in workflow
+    assert "full_mode_sections" in workflow
+    assert "compact_mode_sections" in workflow
+    assert "### Motivation / Context" in workflow
+    assert "### Change Notes" in workflow
+    assert "either full mode sections or compact mode sections" in workflow
     assert "story_generator/issues" in workflow
 
 


### PR DESCRIPTION
﻿## Summary
Adds explicit full and compact PR template modes and updates validation so either mode is accepted.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/22

## Full Mode (Larger/Riskier Change)

### Motivation / Context
Issue `#22` asks for a less rigid PR gate where small docs/chore changes can use concise writeups while larger changes keep deeper context.

### What Changed
- Updated `.github/pull_request_template.md` to document both full and compact modes.
- Updated `.github/workflows/pr-template-check.yml` to require common sections plus either full-mode or compact-mode section sets.
- Updated `tests/test_project_contracts.py` for dual-mode assertions.
- Updated `docs/github_collaboration.md` to describe the dual-mode requirement.

### Tradeoffs and Risks
- Section matching is string-based; future heading edits need synchronized test/workflow updates.

### How This Was Tested
- `uv run pre-commit run --files .github/pull_request_template.md .github/workflows/pr-template-check.yml docs/github_collaboration.md tests/test_project_contracts.py`
- `uv run pytest --no-cov tests/test_project_contracts.py`

### Follow-ups / Future Work (Optional)
- If needed, we can add a PR-mode marker token to reduce ambiguity in section detection.
