### PR TITLE
Strengthen story schema contract tests with golden round-trip fixture

### DIFF
--- a/docs/adr/0019-contract-registry-and-pipeline-governance.md
+++ b/docs/adr/0019-contract-registry-and-pipeline-governance.md
@@ -43,6 +43,13 @@ Developer command:
 - Exported registry JSON must match runtime snapshot in tests.
 - Story analysis orchestration validates input/output stage contracts at runtime.
 
+## Version Migration Policy
+
+- Backward-compatible additions stay within `story_analysis.v1`.
+- Breaking schema changes require a new explicit key (for example `story_analysis.v2`).
+- Storage adapters fail fast when persisted schema version does not match expected version.
+- Registry/docs must declare both old and new versions during migration windows.
+
 ## Test plan
 
 - Add unit tests for runtime registry content and uniqueness.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,3 +87,13 @@ Schema and stage-level pipeline contracts are tracked in:
 - `src/story_gen/api/contract_registry.py`
 - `work/contracts/story_pipeline_contract_registry.v1.json`
 - `src/story_gen/core/pipeline_contracts.py`
+
+## Schema Versioning Policy
+
+Canonical story schema rules:
+
+- `story_analysis.v1` is the current canonical schema key.
+- Backward-compatible additions may be introduced in `v1` without changing the key.
+- Breaking changes require a new schema key (for example `story_analysis.v2`).
+- Persistence adapters must fail fast on schema version mismatches until migrations run.
+- During migrations, both versions must be explicitly tracked in contracts and docs.

--- a/tests/fixtures/story_analysis_v1_golden.json
+++ b/tests/fixtures/story_analysis_v1_golden.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": "story_analysis.v1",
+  "story_id": "story-golden-001",
+  "source_language": "en",
+  "target_language": "en",
+  "raw_segments": [
+    {
+      "segment_id": "seg_001",
+      "source_type": "text",
+      "original_text": "Rhea opens the archive ledger.",
+      "normalized_text": "rhea opens the archive ledger.",
+      "language_code": "en",
+      "translated_text": null,
+      "segment_index": 1,
+      "char_start": 0,
+      "char_end": 31
+    }
+  ],
+  "extracted_events": [
+    {
+      "event_id": "evt_001",
+      "summary": "Rhea discovers the ledger.",
+      "segment_id": "seg_001",
+      "narrative_order": 1,
+      "event_time_utc": null,
+      "entity_names": [
+        "Rhea",
+        "archive ledger"
+      ],
+      "confidence": {
+        "method": "heuristic",
+        "score": 0.82
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:00+00:00",
+        "generator": "story-analysis-pipeline",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "story_beats": [
+    {
+      "beat_id": "beat_001",
+      "stage": "setup",
+      "order_index": 1,
+      "summary": "Discovery of a hidden family record.",
+      "timestamp_utc": null,
+      "evidence_segment_ids": [
+        "seg_001"
+      ],
+      "confidence": {
+        "method": "rule-based",
+        "score": 0.78
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:01+00:00",
+        "generator": "beat-detector",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "theme_signals": [
+    {
+      "theme_id": "theme_truth",
+      "label": "Truth and memory",
+      "stage": "setup",
+      "strength": 0.64,
+      "direction": "emerging",
+      "evidence_segment_ids": [
+        "seg_001"
+      ],
+      "confidence": {
+        "method": "theme-heuristic",
+        "score": 0.73
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:02+00:00",
+        "generator": "theme-tracker",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "entity_mentions": [
+    {
+      "entity_id": "entity_rhea",
+      "name": "Rhea",
+      "entity_type": "character",
+      "mention_count": 1,
+      "segment_ids": [
+        "seg_001"
+      ],
+      "confidence": {
+        "method": "entity-linker",
+        "score": 0.9
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:03+00:00",
+        "generator": "entity-extractor",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "timeline_points": [
+    {
+      "point_id": "point_001",
+      "source_id": "evt_001",
+      "source_type": "event",
+      "label": "Rhea discovers the ledger.",
+      "narrative_order": 1,
+      "actual_time_utc": null,
+      "stage": "setup",
+      "confidence": {
+        "method": "timeline-merge",
+        "score": 0.8
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:04+00:00",
+        "generator": "timeline-composer",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "insights": [
+    {
+      "insight_id": "insight_001",
+      "granularity": "macro",
+      "title": "Truth surfaces through archival evidence",
+      "content": "The story frames discovery of records as the catalyst for broader change.",
+      "stage": "setup",
+      "beat_id": "beat_001",
+      "evidence_segment_ids": [
+        "seg_001"
+      ],
+      "confidence": {
+        "method": "insight-scorer",
+        "score": 0.76
+      },
+      "provenance": {
+        "source_segment_ids": [
+          "seg_001"
+        ],
+        "created_at_utc": "2026-02-09T00:00:05+00:00",
+        "generator": "insight-engine",
+        "generator_version": "v1"
+      }
+    }
+  ],
+  "quality_gate": {
+    "passed": true,
+    "confidence_floor": 0.7,
+    "hallucination_risk": 0.12,
+    "translation_quality": 1.0,
+    "reasons": []
+  }
+}

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -323,6 +323,12 @@ def test_architecture_docs_and_adr_scaffold_exist() -> None:
     assert (ROOT / "docs" / "feature_pipeline.md").exists()
     assert (ROOT / "docs" / "architecture_diagrams.md").exists()
     assert (ROOT / "docs" / "javascripts" / "mermaid.js").exists()
+    architecture = _read("docs/architecture.md")
+    adr_0019 = _read("docs/adr/0019-contract-registry-and-pipeline-governance.md")
+    assert "## Schema Versioning Policy" in architecture
+    assert "story_analysis.v2" in architecture
+    assert "## Version Migration Policy" in adr_0019
+    assert "story_analysis.v2" in adr_0019
 
 
 def test_api_docs_reference_swagger_and_openapi_endpoints() -> None:
@@ -354,6 +360,10 @@ def test_analysis_contract_scaffold_exists_and_is_valid_json() -> None:
         payload = json.loads(path.read_text(encoding="utf-8"))
         assert payload["version"] == "0.1.0"
         assert payload["artifacts"]
+    golden_story = ROOT / "tests" / "fixtures" / "story_analysis_v1_golden.json"
+    assert golden_story.exists()
+    payload = json.loads(golden_story.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "story_analysis.v1"
 
 
 def test_policy_docs_require_failure_path_testing_rules() -> None:

--- a/tests/test_story_schema_golden_fixture.py
+++ b/tests/test_story_schema_golden_fixture.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from story_gen.core.story_schema import StoryDocument
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "story_analysis_v1_golden.json"
+
+
+def test_story_schema_golden_fixture_round_trip_serialization() -> None:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    document = StoryDocument.model_validate(payload)
+    round_trip = json.loads(document.model_dump_json())
+
+    assert round_trip == payload


### PR DESCRIPTION
﻿## Summary
Adds a golden `story_analysis.v1` fixture and explicit round-trip serialization test, plus explicit schema migration policy wording in architecture docs and ADR 0019.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/2

## Full Mode (Larger/Riskier Change)

### Motivation / Context
Issue `#2` requires an explicit round-trip fixture and clearer migration policy guidance for `story_analysis.v1 -> future versions`.

### What Changed
- Added `tests/fixtures/story_analysis_v1_golden.json` as canonical v1 fixture.
- Added `tests/test_story_schema_golden_fixture.py` to validate strict model round-trip serialization.
- Added schema version migration policy section to `docs/architecture.md`.
- Added version migration policy section to `docs/adr/0019-contract-registry-and-pipeline-governance.md`.
- Extended `tests/test_project_contracts.py` to enforce migration-policy docs and fixture presence.

### Tradeoffs and Risks
- Golden fixtures introduce maintenance overhead when schema evolves by design.
- This is intentional to make incompatible contract changes explicit in code review.

### How This Was Tested
- `uv run pre-commit run --files tests/fixtures/story_analysis_v1_golden.json tests/test_story_schema_golden_fixture.py docs/architecture.md docs/adr/0019-contract-registry-and-pipeline-governance.md tests/test_project_contracts.py`
- `uv run pytest --no-cov tests/test_story_schema_golden_fixture.py tests/test_contract_registry.py tests/test_project_contracts.py`

### Follow-ups / Future Work (Optional)
- If/when `story_analysis.v2` is introduced, add parallel v2 fixture and migration compatibility tests.
