### PR TITLE
Harden issue #6 provenance guarantees for arc signals

### DIFF
--- a/docs/adr/0009-story-intelligence-pipeline-and-dashboard-read-models.md
+++ b/docs/adr/0009-story-intelligence-pipeline-and-dashboard-read-models.md
@@ -106,7 +106,7 @@ can power dashboard drilldown without breaking existing heatmap and arc chart cl
 
 - Theme signals must include evidence IDs and provenance source segment IDs with overlap.
 - Theme signal confidence must be positive.
-- Arc/conflict/emotion records must carry evidence and confidence when generated.
+- Arc/conflict/emotion records must carry evidence, provenance segment references, and confidence when generated.
 - Bundle decoding must stay backward compatible with older arc/conflict/emotion payloads.
 
 ### Test plan

--- a/src/story_gen/core/story_bundle.py
+++ b/src/story_gen/core/story_bundle.py
@@ -358,6 +358,9 @@ def _decode_arcs(data: bytes) -> list[ArcSignal]:
             state=str(item["state"]),
             delta=float(item["delta"]),
             evidence_segment_ids=_parse_segment_ids(item.get("evidence_segment_ids")),
+            provenance_segment_ids=_parse_segment_ids(
+                item.get("provenance_segment_ids", item.get("evidence_segment_ids"))
+            ),
             confidence=float(item.get("confidence", 0.0)),
         )
         for item in parsed
@@ -375,6 +378,9 @@ def _decode_conflicts(data: bytes) -> list[ConflictShift]:
             to_state=_parse_story_stage(item["to_state"]),
             intensity_delta=float(item["intensity_delta"]),
             evidence_segment_ids=_parse_segment_ids(item.get("evidence_segment_ids")),
+            provenance_segment_ids=_parse_segment_ids(
+                item.get("provenance_segment_ids", item.get("evidence_segment_ids"))
+            ),
             confidence=float(item.get("confidence", 0.0)),
         )
         for item in parsed
@@ -391,6 +397,9 @@ def _decode_emotions(data: bytes) -> list[EmotionSignal]:
             tone=str(item["tone"]),
             score=float(item["score"]),
             evidence_segment_ids=_parse_segment_ids(item.get("evidence_segment_ids")),
+            provenance_segment_ids=_parse_segment_ids(
+                item.get("provenance_segment_ids", item.get("evidence_segment_ids"))
+            ),
             confidence=float(item.get("confidence", 0.0)),
         )
         for item in parsed

--- a/tests/test_story_bundle.py
+++ b/tests/test_story_bundle.py
@@ -40,14 +40,22 @@ def test_story_bundle_roundtrip_restores_analysis_artifacts() -> None:
     assert len(unpacked.emotions) == len(result.emotions)
     if unpacked.arcs:
         assert unpacked.arcs[0].evidence_segment_ids == result.arcs[0].evidence_segment_ids
+        assert unpacked.arcs[0].provenance_segment_ids == result.arcs[0].provenance_segment_ids
         assert unpacked.arcs[0].confidence == result.arcs[0].confidence
     if unpacked.conflicts:
         assert (
             unpacked.conflicts[0].evidence_segment_ids == result.conflicts[0].evidence_segment_ids
         )
+        assert (
+            unpacked.conflicts[0].provenance_segment_ids
+            == result.conflicts[0].provenance_segment_ids
+        )
         assert unpacked.conflicts[0].confidence == result.conflicts[0].confidence
     if unpacked.emotions:
         assert unpacked.emotions[0].evidence_segment_ids == result.emotions[0].evidence_segment_ids
+        assert (
+            unpacked.emotions[0].provenance_segment_ids == result.emotions[0].provenance_segment_ids
+        )
         assert unpacked.emotions[0].confidence == result.emotions[0].confidence
     assert unpacked.graph_svg.startswith("<svg")
 

--- a/tests/test_theme_arc_tracking.py
+++ b/tests/test_theme_arc_tracking.py
@@ -100,12 +100,26 @@ def test_theme_tracking_captures_strengthening_then_fading_with_evidence() -> No
     assert len(arcs) == 4
     assert any(arc.state == "fading" for arc in arcs)
     assert all(arc.evidence_segment_ids for arc in arcs)
+    assert all(arc.provenance_segment_ids for arc in arcs)
+    assert all(
+        set(arc.evidence_segment_ids).intersection(arc.provenance_segment_ids) for arc in arcs
+    )
     assert all(arc.confidence > 0.0 for arc in arcs)
 
     assert len(conflicts) == 3
     assert all(conflict.evidence_segment_ids for conflict in conflicts)
+    assert all(conflict.provenance_segment_ids for conflict in conflicts)
+    assert all(
+        set(conflict.evidence_segment_ids).intersection(conflict.provenance_segment_ids)
+        for conflict in conflicts
+    )
     assert all(conflict.confidence > 0.0 for conflict in conflicts)
 
     assert len(emotions) == 4
     assert all(emotion.evidence_segment_ids for emotion in emotions)
+    assert all(emotion.provenance_segment_ids for emotion in emotions)
+    assert all(
+        set(emotion.evidence_segment_ids).intersection(emotion.provenance_segment_ids)
+        for emotion in emotions
+    )
     assert all(emotion.confidence > 0.0 for emotion in emotions)


### PR DESCRIPTION
## Summary
Follow-up hardening for previously closed issue #6: make provenance references explicit and validated for arc/conflict/emotion signals, not just theme signals.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/6

### Change Notes
- Added `provenance_segment_ids` to `ArcSignal`, `ConflictShift`, and `EmotionSignal`.
- Added runtime validation that each signal has evidence + provenance with overlap and positive confidence.
- Updated bundle decoding to read `provenance_segment_ids` with backward-compatible fallback to `evidence_segment_ids` for older bundles.
- Extended regression tests and ADR language to reflect explicit provenance guarantees.

### Validation
- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run mkdocs build --strict`
- `uv run pre-commit run --all-files`