### PR TITLE
Automate GitHub wiki sync from docs

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,41 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - "docs/**"
+      - "tools/sync_wiki.py"
+      - ".github/workflows/wiki-sync.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "wiki-sync-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync docs into wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/sync_wiki.py \
+            --push \
+            --wiki-dir "$RUNNER_TEMP/story_generator.wiki" \
+            --wiki-remote "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" \
+            --commit-message "docs(wiki): sync from ${GITHUB_SHA}"

--- a/docs/adr/0018-wiki-docs-and-product-first-pages.md
+++ b/docs/adr/0018-wiki-docs-and-product-first-pages.md
@@ -26,6 +26,7 @@ Adopt a two-surface model with clear ownership:
 
 - Author docs in repository `docs/`.
 - Mirror docs to the GitHub wiki via a repeatable sync tool.
+- Automate wiki synchronization from `docs/` using a GitHub Actions workflow.
 - Publish the offline studio demo at GitHub Pages root.
 - Keep `/studio` as a compatibility alias to the same static demo build.
 - Add `/docs` redirect on Pages pointing to the wiki.
@@ -40,6 +41,7 @@ Developer commands:
 Tooling:
 
 - `tools/sync_wiki.py`
+- `.github/workflows/wiki-sync.yml`
 
 Public URLs:
 
@@ -50,6 +52,7 @@ Public URLs:
 
 - `docs/` remains the authored documentation source.
 - Wiki content is generated from `docs/` and not hand-maintained as primary.
+- Wiki automation runs on `develop`/`main` pushes for docs/sync-tool changes and by manual dispatch.
 - GitHub Pages deploys static product demo artifacts only.
 - Pages keeps an explicit route to wiki docs.
 

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -33,6 +33,12 @@ make pr-auto
 
 Docs are authored in `docs/` and mirrored into the repo wiki.
 
+Automation:
+
+- `.github/workflows/wiki-sync.yml` syncs wiki content on pushes to `develop`/`main`
+  when docs or sync tooling changes.
+- You can also run the same sync workflow manually from the Actions tab.
+
 ```bash
 make wiki-sync       # update local wiki clone from docs/
 make wiki-sync-push  # publish synced docs to GitHub wiki


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to automatically sync repository docs into the GitHub wiki.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/40

### Motivation / Context
Now that the wiki has been initialized, syncing should not rely on manual local commands. Automating this keeps wiki docs current with `docs/` and removes drift between authored docs and published wiki pages.

### What Changed
- Added `.github/workflows/wiki-sync.yml`.
- Workflow triggers:
  - push to `develop`/`main` when docs or sync tooling changes.
  - manual `workflow_dispatch`.
- Workflow uses least-privilege repo token (`contents: write`) and pinned action SHA (`actions/checkout`).
- Workflow runs `tools/sync_wiki.py --push` against the wiki remote with token auth.
- Updated ADR 0018 and collaboration docs to describe automated wiki sync behavior.

### Tradeoffs and Risks
- Each docs update can generate wiki commits; history is clean but more active.
- Workflow depends on repo token write permissions for actions.

### How This Was Tested
- `uv run pre-commit run --all-files`
- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run mypy`
- `uv run pytest`
- `uv run mkdocs build --strict`