### PR TITLE
Fix BOM handling in issue close summary validation

### DIFF
--- a/tests/test_close_issue.py
+++ b/tests/test_close_issue.py
@@ -60,3 +60,8 @@ def test_validate_summary_rejects_placeholder_tokens() -> None:
     with_placeholder = VALID_SUMMARY.replace("pipeline", "<component>")
     problems = validate_summary(with_placeholder)
     assert any("Replace placeholder tokens" in problem for problem in problems)
+
+
+def test_validate_summary_accepts_utf8_bom_prefix() -> None:
+    problems = validate_summary("\ufeff" + VALID_SUMMARY)
+    assert problems == []

--- a/tools/close_issue.py
+++ b/tools/close_issue.py
@@ -62,7 +62,7 @@ def _normalize_section_name(raw: str) -> str:
 def _extract_markdown_sections(text: str) -> set[str]:
     sections: set[str] = set()
     for line in text.splitlines():
-        stripped = line.strip()
+        stripped = line.lstrip("\ufeff").strip()
         if not stripped:
             continue
 


### PR DESCRIPTION
## Summary
Fixes a parser edge case in the issue close-summary tool so UTF-8 BOM-prefixed files validate correctly.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/65

## Compact Mode (Small/Low-Risk Change)

### Change Notes
- Updated `tools/close_issue.py` to strip a UTF-8 BOM before section parsing.
- Added a regression test in `tests/test_close_issue.py` for BOM-prefixed content.

### Validation
- `uv run ruff check tools/close_issue.py tests/test_close_issue.py`
- `uv run pytest --no-cov tests/test_close_issue.py`
- `uv run pre-commit run --all-files`