### PR TITLE
Formalize docs ownership split

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,21 @@ When closing an issue, always add a structured summary comment first, then close
 - Required headings: `Work Summary`, `Objective`, `Root Cause`, `Approach`, `Implementation Details`, `Validation`, and `Ownership / Follow-ups`.
 - Include concrete artifacts (PR URLs, commit SHAs, tests executed).
 - Use `make issue-close ISSUE_NUMBER=<n> ISSUE_SUMMARY_FILE=<path>` so closure and summary stay paired.
+
+## 13. Documentation Ownership Split
+
+Use one clear source of truth per documentation type:
+
+- Repo docs (`docs/`, API contracts, architecture, ADRs, runbooks tied to code) hold versioned technical truth.
+- Wiki holds collaborative/project-operations material (roadmap context, planning notes, meeting outcomes, onboarding checklists, weekly change notes).
+- GitHub Pages holds public product/demo narrative (what the product is, what it looks like, lightweight usage path).
+
+Rule of thumb:
+
+- If content must stay correct for a specific commit/release, keep it in repo docs.
+- If content is operational/collaborative and can evolve independently, keep it in wiki.
+
+Guardrail:
+
+- Avoid duplicate docs across repo and wiki; keep one source and link from the other.
+- For API/code documentation, repo docs are always the source of truth.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Not included on purpose:
 - Project board: https://github.com/users/ringxworld/projects/2
 - Security policy: `SECURITY.md`
 
+## Documentation ownership
+
+- Repo docs (`docs/`, contracts, architecture, ADRs): versioned technical source of truth.
+- Wiki: collaborative/project-operations context (planning, decisions, onboarding, weekly updates).
+- Pages: public product/demo narrative.
+
+Rule of thumb:
+
+- Commit/release-accurate content belongs in repo docs.
+- Operational content that can evolve independently belongs in wiki.
+
+Guardrail:
+
+- Avoid duplicated docs across repo and wiki; keep one source and link from the other.
+- API/code docs stay source-of-truth in repo docs.
+
 ## Run locally
 
 From repository root:


### PR DESCRIPTION
## Summary
Formalizes documentation ownership boundaries so repo docs, wiki content, and Pages narrative have clear source-of-truth rules.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/72

## Compact Mode (Small/Low-Risk Change)

### Change Notes
- Added a new `Documentation Ownership Split` policy section to `AGENTS.md`.
- Added a concise `Documentation ownership` section to `README.md` for contributor-facing guidance.
- Included explicit anti-duplication guardrail and API/code source-of-truth rule.

### Validation
- `uv run pre-commit run --all-files`