### PR TITLE
Codify adversarial closed-issue verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,3 +187,17 @@ Treat external issues as intake signals, not automatic roadmap commitments:
 - Label external intake explicitly (`external`, `needs-triage`) and only assign priority after review.
 - If details are insufficient, require clarification (`needs-info`) before implementation planning.
 - Internal execution templates (for example `[task]`) are maintainer-only; external task-form submissions are closed as `not planned`.
+
+## 15. Adversarial Issue-Closure Verification
+
+Treat closed issues as untrusted until verified:
+
+- Assume closure summaries can over-promise; verify acceptance criteria against merged artifacts or explicit manual checks.
+- Evidence order: merged PRs + tests > merged PRs only > manual platform verification notes.
+- If acceptance criteria are not evidenced, do not leave the issue quietly closed.
+
+Decision policy when evidence is insufficient:
+
+- Reopen the issue when core acceptance criteria are still unmet.
+- Create a linked follow-up issue when the original outcome is mostly valid but verifiability or hardening is missing.
+- Record the verification result in a comment using concrete artifacts (PR URLs, commands run, current state observed).

--- a/docs/audits/2026-02-09-closed-issue-verification.md
+++ b/docs/audits/2026-02-09-closed-issue-verification.md
@@ -1,0 +1,46 @@
+# Closed-Issue Verification Audit (2026-02-09)
+
+## Scope
+
+- Audited all currently closed issues in `ringxworld/story_generator`.
+- Applied adversarial posture: assume closure claims may over-promise until verified.
+
+## Method
+
+- Verified each closed issue has a structured `Work Summary` comment.
+- Mapped issue threads to linked PR references (URL and `#PR` mentions).
+- Verified linked PR states in GitHub (`MERGED` vs not merged).
+- Re-checked manual/governance acceptance criteria directly via live repo/project state.
+
+## Results
+
+- Closed issues audited: `20`
+- Closed issues with `Work Summary`: `20`
+- Closed issues with merged PR evidence: `18`
+- Closed issues without PR artifacts: `2` (`#14`, `#15`)
+
+## Findings
+
+1. `#14 Human-friendly issue labels`
+- Current live label taxonomy appears consistent with stated acceptance criteria.
+- No merged PR artifact exists for original closure (manual GitHub-side change).
+- Follow-up opened for automation hardening: `#80`.
+
+2. `#15 Set up project board for issue tracking`
+- Current project board state passes `tools/project_board_audit.py` and includes expected roadmap coverage.
+- No merged PR artifact exists for original closure (manual GitHub-side change).
+- Current evidence is acceptable, but this class of change remains governance/manual by nature.
+
+## Actions Taken
+
+- Backfilled/confirmed structured close summaries for all closed issues.
+- Added repository rule in `AGENTS.md`:
+  - `## 15. Adversarial Issue-Closure Verification`
+- Opened follow-up issues:
+  - `#79` Codify adversarial issue-closure verification protocol
+  - `#80` Automate label taxonomy audit for closure verification
+
+## Residual Risk
+
+- Manual GitHub configuration changes can still drift without direct code artifacts.
+- Continue preferring automation-backed checks for governance states whenever feasible.


### PR DESCRIPTION
## Summary
Adds an explicit adversarial closure-verification rule and a dated audit record of current closed-issue state, so closure claims are treated as suspect until evidenced.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/79
- https://github.com/ringxworld/story_generator/issues/80

## Compact Mode (Small/Low-Risk Change)

### Change Notes
- Added `## 15. Adversarial Issue-Closure Verification` to `AGENTS.md` with reopen vs follow-up decision policy.
- Added `docs/audits/2026-02-09-closed-issue-verification.md` documenting closed-issue audit method, findings, and residual risk.
- Recorded that issues `#14` and `#15` are currently satisfied by live state but lack original PR artifacts, with automation follow-up tracked.

### Validation
- `uv run pre-commit run --all-files`