### PR TITLE
Automate Dependabot PR triage and safe auto-merge

### DIFF
--- a/.github/workflows/dependabot-autoflow.yml
+++ b/.github/workflows/dependabot-autoflow.yml
@@ -1,0 +1,158 @@
+name: Dependabot Autoflow
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  handle:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triage and auto-merge Dependabot PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = pr.number;
+            const marker = "<!-- dependabot-autoflow -->";
+            const title = pr.title || "";
+
+            function classifySemverFromTitle(value) {
+              const match = value.match(/ from v?(\d+)\.(\d+)\.(\d+)[^\s]* to v?(\d+)\.(\d+)\.(\d+)[^\s]*/i);
+              if (!match) return "unknown";
+              const [, fromMaj, fromMin, fromPatch, toMaj, toMin, toPatch] = match.map(Number);
+              if (toMaj > fromMaj) return "major";
+              if (toMaj === fromMaj && toMin > fromMin) return "minor";
+              if (toMaj === fromMaj && toMin === fromMin && toPatch > fromPatch) return "patch";
+              return "unknown";
+            }
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color,
+                  description,
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+              }
+            }
+
+            async function upsertComment(body) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (comment) =>
+                  comment.user?.login === "github-actions[bot]" &&
+                  comment.body?.includes(marker),
+              );
+              const payload = `${marker}\n${body}`;
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body: payload,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: payload,
+                });
+              }
+            }
+
+            await ensureLabel("dependabot", "0366d6", "Automated dependency updates from Dependabot.");
+            await ensureLabel("automerge-candidate", "0e8a16", "Eligible for auto-merge after required checks.");
+            await ensureLabel("needs-manual-review", "b60205", "Dependency update requires manual maintainer review.");
+
+            const updateType = classifySemverFromTitle(title);
+            const labels = new Set((pr.labels || []).map((label) => label.name));
+            labels.add("dependencies");
+            labels.add("dependabot");
+
+            if (updateType === "patch" || updateType === "minor") {
+              labels.add("automerge-candidate");
+              labels.delete("needs-manual-review");
+            } else {
+              labels.add("needs-manual-review");
+              labels.delete("automerge-candidate");
+            }
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: Array.from(labels),
+            });
+
+            if (updateType === "patch" || updateType === "minor") {
+              try {
+                await github.graphql(
+                  `
+                    mutation($pullRequestId: ID!) {
+                      enablePullRequestAutoMerge(
+                        input: { pullRequestId: $pullRequestId, mergeMethod: SQUASH }
+                      ) {
+                        pullRequest {
+                          number
+                        }
+                      }
+                    }
+                  `,
+                  { pullRequestId: pr.node_id },
+                );
+
+                await upsertComment(
+                  [
+                    "Dependabot update triaged as non-major semver bump.",
+                    "",
+                    `- Update type: \`${updateType}\``,
+                    "- Action: auto-merge enabled (will merge after required checks pass).",
+                  ].join("\n"),
+                );
+              } catch (error) {
+                await upsertComment(
+                  [
+                    "Dependabot update triaged as non-major semver bump.",
+                    "",
+                    `- Update type: \`${updateType}\``,
+                    "- Action: attempted auto-merge enable but GitHub rejected it.",
+                    `- Reason: ${error.message}`,
+                    "- Next step: merge manually after checks pass.",
+                  ].join("\n"),
+                );
+              }
+              return;
+            }
+
+            await upsertComment(
+              [
+                "Dependabot update requires manual review before merge.",
+                "",
+                `- Update type: \`${updateType}\``,
+                "- Action: auto-merge not enabled.",
+                "- Next step: maintainer review for compatibility/risk.",
+              ].join("\n"),
+            );

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,3 +201,12 @@ Decision policy when evidence is insufficient:
 - Reopen the issue when core acceptance criteria are still unmet.
 - Create a linked follow-up issue when the original outcome is mostly valid but verifiability or hardening is missing.
 - Record the verification result in a comment using concrete artifacts (PR URLs, commands run, current state observed).
+
+## 16. Dependabot Handling
+
+Treat Dependabot PRs as first-class maintenance work:
+
+- Always triage Dependabot PRs when they arrive; do not leave them unattended.
+- Prefer automated merge for safe semver bumps (patch/minor) after required checks pass.
+- Require manual review for major/ambiguous updates before merge.
+- If a Dependabot PR fails checks, identify whether the failure is dependency-driven and add/adjust tests to guard the compatibility gap before merge.


### PR DESCRIPTION
## Summary
Adds a Dependabot autopilot flow so incoming dependency PRs are always triaged and safe updates are automatically merged after checks pass.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/84

## Compact Mode (Small/Low-Risk Change)

### Change Notes
- Added `.github/workflows/dependabot-autoflow.yml` for Dependabot PR triage.
- Workflow classifies update type from title semver diff, labels PRs, posts a sticky status comment, and enables auto-merge for patch/minor updates.
- Major/unknown updates are explicitly flagged `needs-manual-review`.
- Added a permanent Dependabot handling rule to `AGENTS.md`.

### Validation
- `uv run pre-commit run --all-files`