### PR TITLE
Fix Dependabot missing label for Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,4 @@ updates:
       timezone: "UTC"
     labels:
       - "dependencies"
-      - "ci/cd"
+      - "CI"


### PR DESCRIPTION
## Summary

Fixes Dependabot label configuration for GitHub Actions updates by replacing a non-existent label value with an existing repository label.

## Linked Issues

- https://github.com/ringxworld/story_generator/issues/88

## Merge Gates

Before requesting merge, expect these required checks to pass on `develop`/`main`:

- `label`
- `pr-template`
- `quality`
- `frontend`
- `pages`
- `native`
- `docker`

Local command that mirrors the full gate:

- `make check`

## Compact Mode (Small/Low-Risk Change)

### Change Notes

- What changed in plain language: Updated `.github/dependabot.yml` to use `CI` instead of `ci/cd` for `github-actions` updates.
- Why this small change matters: Dependabot can now apply labels without raising config errors.

### Validation

- Checks run (or reason skipped): `uv run pre-commit run --files .github/dependabot.yml`