### PR TITLE
Pin github-script workflow actions to immutable SHA

### DIFF
--- a/.github/workflows/branch-failure-notify.yml
+++ b/.github/workflows/branch-failure-notify.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Find open tracker issue
         id: tracker
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const marker = '[ci-failure-tracker]';
@@ -44,7 +44,7 @@ jobs:
       - name: Create tracker issue if missing
         if: steps.tracker.outputs.issue_number == ''
         id: created
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_NAME: ${{ github.event.workflow_run.name }}
@@ -68,7 +68,7 @@ jobs:
             core.setOutput('issue_number', String(issue.number));
 
       - name: Append failure entry
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_NAME: ${{ github.event.workflow_run.name }}

--- a/.github/workflows/dependabot-autoflow.yml
+++ b/.github/workflows/dependabot-autoflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Triage and auto-merge Dependabot PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply intake guardrails
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/meta-audit-notify.yml
+++ b/.github/workflows/meta-audit-notify.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upsert manual intervention tracker issue
         if: steps.findings.outputs.has_findings == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           FINDINGS: ${{ steps.findings.outputs.summary }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

Pins all remaining `actions/github-script` workflow references to immutable SHA to complete CI/CD hardening requirements around action supply-chain drift.

## Linked Issues

- https://github.com/ringxworld/story_generator/issues/37

## Merge Gates

Before requesting merge, expect these required checks to pass on `develop`/`main`:

- `label`
- `pr-template`
- `quality`
- `frontend`
- `pages`
- `native`
- `docker`

Local command that mirrors the full gate:

- `make check`

## Compact Mode (Small/Low-Risk Change)

### Change Notes

- What changed in plain language: Replaced tag-based `actions/github-script@v7/v8` with pinned SHA `@ed597411d8f924073f98dfc5c65a23a2325f34cd` in four workflows.
- Why this small change matters: Closes the remaining hardening gap in issue #37 by removing mutable tag references.

### Validation

- Checks run (or reason skipped):
  - `uv run pre-commit run --files .github/workflows/branch-failure-notify.yml .github/workflows/dependabot-autoflow.yml .github/workflows/issue-intake.yml .github/workflows/meta-audit-notify.yml`
  - `uv run pytest`