### PR TITLE
Host MkDocs docs on Pages under /docs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,12 +29,24 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
       - name: Setup Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
+
+      - name: Build docs snapshot
+        run: uv run mkdocs build --strict --site-dir docs_site
 
       - name: Build product demo snapshot
         env:
@@ -47,27 +59,8 @@ jobs:
           cp -R web/dist/. site/
           mkdir -p site/studio
           cp -R web/dist/. site/studio/
-
-      - name: Add wiki redirect page
-        run: |
           mkdir -p site/docs
-          cat > site/docs/index.html <<'EOF'
-          <!doctype html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <title>Docs moved to wiki</title>
-            <meta http-equiv="refresh" content="0; url=https://github.com/${{ github.repository }}/wiki" />
-          </head>
-          <body>
-            <p>
-              Docs now live in the wiki:
-              <a href="https://github.com/${{ github.repository }}/wiki">open wiki</a>
-            </p>
-          </body>
-          </html>
-          EOF
+          cp -R docs_site/. site/docs/
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Use one clear source of truth per documentation type:
 
 - Repo docs (`docs/`, API contracts, architecture, ADRs, runbooks tied to code) hold versioned technical truth.
 - Wiki holds collaborative/project-operations material (roadmap context, planning notes, meeting outcomes, onboarding checklists, weekly change notes).
-- GitHub Pages holds public product/demo narrative (what the product is, what it looks like, lightweight usage path).
+- GitHub Pages holds public product/demo narrative and a static docs snapshot at `/docs/`.
 
 Rule of thumb:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Not included on purpose:
 
 - Product demo (GitHub Pages): https://ringxworld.github.io/story_generator/
 - Studio alias: https://ringxworld.github.io/story_generator/studio/
-- Wiki (primary docs): https://github.com/ringxworld/story_generator/wiki
+- Hosted technical docs (Pages): https://ringxworld.github.io/story_generator/docs/
+- Wiki (collaboration/ops notes): https://github.com/ringxworld/story_generator/wiki
 - Project board: https://github.com/users/ringxworld/projects/2
 - Security policy: `SECURITY.md`
 
@@ -67,7 +68,7 @@ Not included on purpose:
 
 - Repo docs (`docs/`, contracts, architecture, ADRs): versioned technical source of truth.
 - Wiki: collaborative/project-operations context (planning, decisions, onboarding, weekly updates).
-- Pages: public product/demo narrative.
+- Pages: public product/demo surface plus a static docs snapshot under `/docs/`.
 
 Rule of thumb:
 

--- a/docs/adr/0018-wiki-docs-and-product-first-pages.md
+++ b/docs/adr/0018-wiki-docs-and-product-first-pages.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+> Note: The `/docs` redirect portion of this ADR is superseded by
+> `0020-pages-hosted-mkdocs-snapshot.md`. Pages now hosts a static MkDocs
+> snapshot under `/docs/` while wiki sync remains in place.
+
 ## Problem
 
 The repository has two public documentation surfaces:

--- a/docs/adr/0020-pages-hosted-mkdocs-snapshot.md
+++ b/docs/adr/0020-pages-hosted-mkdocs-snapshot.md
@@ -1,0 +1,45 @@
+# ADR 0020: Host MkDocs Snapshot on GitHub Pages
+
+## Status
+
+Accepted
+
+## Problem
+
+Repository docs are authored in `docs/` and mirrored to wiki, but the Pages
+deployment only served product demo assets and redirected `/docs` to wiki.
+That left no hosted static docs snapshot on Pages for users who expect
+versioned technical docs under the project site.
+
+## Non-goals
+
+- Replacing wiki sync for collaborative/project-ops notes.
+- Hosting dynamic Python API docs (Swagger/ReDoc) on Pages.
+- Introducing a second authored docs source.
+
+## Public API
+
+Pages URLs:
+
+- Product demo root: `https://ringxworld.github.io/story_generator/`
+- Studio alias: `https://ringxworld.github.io/story_generator/studio/`
+- Hosted static docs: `https://ringxworld.github.io/story_generator/docs/`
+
+Workflow behavior:
+
+- `.github/workflows/deploy-pages.yml` now builds MkDocs and publishes the
+  output under `/docs/` in the Pages artifact.
+
+## Invariants
+
+- `docs/` remains the single authored source for technical documentation.
+- Wiki sync remains enabled for collaborative/project-ops notes.
+- Pages continues to publish the offline studio/demo at root and `/studio`.
+- Pages docs are a static snapshot from the same commit as the deployed demo.
+
+## Test plan
+
+- Validate `deploy-pages.yml` builds MkDocs and copies output into `site/docs/`.
+- Validate CI contract tests assert hosted docs staging behavior.
+- Validate Pages deployment contains a browsable docs snapshot at `/docs/`.
+- Run full repository checks before merge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,4 @@ Start from `0000-template.md`.
 Latest ADR:
 
 - `0019-contract-registry-and-pipeline-governance.md`
-
-Latest ADR:
-
-- `0018-wiki-docs-and-product-first-pages.md`
+- `0020-pages-hosted-mkdocs-snapshot.md`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,8 +2,8 @@
 
 ## Current split
 
-- GitHub Wiki: long-form docs and ADR reading surface
-- GitHub Pages: product-first static studio demo snapshot
+- GitHub Wiki: collaboration and project-operations notes
+- GitHub Pages: product-first static studio demo snapshot plus hosted docs under `/docs`
 - React + TypeScript studio (`web/`): local dev now, static hosting ready
 - FastAPI service: local runtime today, external backend host later
 - Persistence: SQLite (`work/local/story_gen.db`) for local or single-instance deployments
@@ -69,7 +69,8 @@ S3-compatible note:
 ## Near-term plan
 
 1. Keep Pages focused on the product demo at repo root.
-2. Keep docs mirrored into the repository wiki.
+2. Publish static docs snapshot on Pages under `/docs`.
+3. Keep docs mirrored into the repository wiki for collaborative edits.
 3. Keep API local-first for editing and workflow testing.
 4. Keep web studio and Python interface on one shared blueprint contract.
 5. Add CORS + stronger auth + storage migration when remote multi-user hosting is needed.
@@ -84,6 +85,10 @@ Repository docs remain authored in `docs/` and are mirrored to the wiki:
 Wiki URL:
 
 - `https://github.com/ringxworld/story_generator/wiki`
+
+Hosted docs URL:
+
+- `https://ringxworld.github.io/story_generator/docs/`
 
 ## Migration path
 

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -29,24 +29,24 @@ One-command flow:
 make pr-auto
 ```
 
-## Wiki docs sync
+## Docs publishing
 
-Docs are authored in `docs/` and mirrored into the repo wiki.
+Docs are authored in `docs/` and published to two read surfaces:
+
+- static snapshot on Pages: `https://ringxworld.github.io/story_generator/docs/`
+- mirrored wiki for collaboration notes: `https://github.com/ringxworld/story_generator/wiki`
 
 Automation:
 
 - `.github/workflows/wiki-sync.yml` syncs wiki content on pushes to `develop`/`main`
   when docs or sync tooling changes.
 - You can also run the same sync workflow manually from the Actions tab.
+- `.github/workflows/deploy-pages.yml` builds MkDocs and publishes it under `/docs/` after successful CI on `develop`/`main`.
 
 ```bash
 make wiki-sync       # update local wiki clone from docs/
 make wiki-sync-push  # publish synced docs to GitHub wiki
 ```
-
-Wiki URL:
-
-- `https://github.com/ringxworld/story_generator/wiki`
 
 ## Pull request defaults in this repo
 

--- a/docs/wiki_docs.md
+++ b/docs/wiki_docs.md
@@ -1,7 +1,7 @@
 # Wiki Docs Sync
 
-Long-form docs are authored in-repo under `docs/` and mirrored to the
-GitHub wiki.
+Long-form docs are authored in-repo under `docs/`, published as a static
+snapshot on GitHub Pages under `/docs/`, and mirrored to the GitHub wiki.
 
 ## Why this split
 
@@ -27,3 +27,4 @@ make wiki-sync-push
 
 - Wiki: `https://github.com/ringxworld/story_generator/wiki`
 - Product demo (Pages): `https://ringxworld.github.io/story_generator/`
+- Hosted docs (Pages): `https://ringxworld.github.io/story_generator/docs/`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - 0017 Story Bundle Binary Format: adr/0017-story-bundle-binary-format.md
       - 0019 Contract Registry and Pipeline Governance: adr/0019-contract-registry-and-pipeline-governance.md
       - 0018 Wiki Docs + Product-First Pages: adr/0018-wiki-docs-and-product-first-pages.md
+      - 0020 Pages Hosted MkDocs Snapshot: adr/0020-pages-hosted-mkdocs-snapshot.md
   - Guides:
       - Dependency Charts: dependency_charts.md
       - Reference Pipeline: reference_pipeline.md

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -92,15 +92,19 @@ def test_deploy_workflow_requires_ci_success() -> None:
     assert "conclusion == 'success'" in workflow
     assert "head_branch == 'develop'" in workflow
     assert "head_branch == 'main'" in workflow
+    assert "Setup uv" in workflow
+    assert "uv python install 3.11" in workflow
+    assert "uv sync --group dev" in workflow
+    assert "Build docs snapshot" in workflow
+    assert "uv run mkdocs build --strict --site-dir docs_site" in workflow
     assert "Setup Node" in workflow
     assert "Build product demo snapshot" in workflow
     assert "VITE_BASE_PATH: /${{ github.event.repository.name }}/" in workflow
     assert "cp -R web/dist/. site/" in workflow
     assert "npm run --prefix web build" in workflow
     assert "site/studio" in workflow
-    assert "Add wiki redirect page" in workflow
-    assert "site/docs/index.html" in workflow
-    assert "/wiki" in workflow
+    assert "site/docs" in workflow
+    assert "cp -R docs_site/. site/docs/" in workflow
 
 
 def test_native_cmake_scaffold_present() -> None:
@@ -215,6 +219,7 @@ def test_mkdocs_configuration_exists() -> None:
     assert "0017 Story Bundle Binary Format:" in config
     assert "0019 Contract Registry and Pipeline Governance:" in config
     assert "0018 Wiki Docs + Product-First Pages:" in config
+    assert "0020 Pages Hosted MkDocs Snapshot:" in config
     assert "pymdownx.superfences" in config
     assert "mermaid.min.js" in config
     assert "javascripts/mermaid.js" in config


### PR DESCRIPTION
## Summary

Switches GitHub Pages from a `/docs` wiki redirect to a real hosted MkDocs snapshot under `/docs/`, while keeping root product demo + `/studio` behavior intact.

## Linked Issues

- https://github.com/ringxworld/story_generator/issues/102

## Merge Gates

Before requesting merge, expect these required checks to pass on `develop`/`main`:

- `label`
- `pr-template`
- `quality`
- `frontend`
- `pages`
- `native`
- `docker`

Local command that mirrors the full gate:

- `make check`

## Full Mode (Larger/Riskier Change)

### Motivation / Context

Pages was not actually hosting technical docs; `/docs` redirected to wiki. This blocked the expected static docs surface for users who navigate the project site directly.

### What Changed

- Updated `.github/workflows/deploy-pages.yml` to:
  - set up Python/uv in deploy workflow,
  - build MkDocs snapshot (`docs_site`),
  - publish docs at `site/docs/`.
- Removed the old wiki redirect page generation step.
- Added ADR `docs/adr/0020-pages-hosted-mkdocs-snapshot.md` and marked ADR 0018 redirect behavior as superseded.
- Updated docs/policy references in `README.md`, `AGENTS.md`, `docs/deployment.md`, `docs/wiki_docs.md`, `docs/github_collaboration.md`, and ADR index.
- Updated `tests/test_project_contracts.py` to assert new deploy workflow behavior.

### Tradeoffs and Risks

- Pages deploy now installs Python deps in addition to Node deps, so deploy job time increases.
- Wiki remains active for collaboration notes, so docs now have two read surfaces by design; source-of-truth remains repo `docs/`.

### How This Was Tested

- `uv run pre-commit run --files .github/workflows/deploy-pages.yml tests/test_project_contracts.py README.md AGENTS.md docs/deployment.md docs/wiki_docs.md docs/github_collaboration.md docs/adr/README.md docs/adr/0018-wiki-docs-and-product-first-pages.md docs/adr/0020-pages-hosted-mkdocs-snapshot.md mkdocs.yml`
- `uv run mkdocs build --strict`
- `uv run pytest`