### PR TITLE
Host Python API reference on Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Build docs snapshot
         run: uv run mkdocs build --strict --site-dir docs_site
 
+      - name: Build Python API reference snapshot
+        run: |
+          uv run python tools/build_python_api_docs.py --output-dir pydoc_site
+
       - name: Build product demo snapshot
         env:
           VITE_OFFLINE_DEMO: "true"
@@ -61,6 +65,8 @@ jobs:
           cp -R web/dist/. site/studio/
           mkdir -p site/docs
           cp -R docs_site/. site/docs/
+          mkdir -p site/pydoc
+          cp -R pydoc_site/. site/pydoc/
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Not included on purpose:
 - Product demo (GitHub Pages): https://ringxworld.github.io/story_generator/
 - Studio alias: https://ringxworld.github.io/story_generator/studio/
 - Hosted technical docs (Pages): https://ringxworld.github.io/story_generator/docs/
+- Hosted Python API reference (Pages): https://ringxworld.github.io/story_generator/pydoc/
 - Wiki (collaboration/ops notes): https://github.com/ringxworld/story_generator/wiki
 - Project board: https://github.com/users/ringxworld/projects/2
 - Security policy: `SECURITY.md`

--- a/docs/adr/0021-pages-hosted-python-api-reference.md
+++ b/docs/adr/0021-pages-hosted-python-api-reference.md
@@ -1,0 +1,34 @@
+# 0021 Pages Hosted Python API Reference
+
+## Problem
+
+The project published a static product demo and MkDocs documentation on GitHub Pages, but not a hosted Python API reference. Users had to run the API locally or inspect source directly to browse Python module interfaces.
+
+## Non-goals
+
+- Replacing FastAPI Swagger/ReDoc for runtime endpoint interaction.
+- Publishing execution-capable backend services on GitHub Pages.
+- Guaranteeing stable deep links for private/internal symbols.
+
+## Public API
+
+- GitHub Pages now includes a static Python API reference surface at `/pydoc/`.
+- README and docs expose explicit links for:
+  - product demo (`/`)
+  - technical docs (`/docs/`)
+  - Python module reference (`/pydoc/`)
+
+## Invariants
+
+- Pages deploy remains gated by successful CI on `develop` or `main`.
+- Hosted Python API reference is generated from repository source in CI, not hand-authored.
+- Static hosting boundaries remain unchanged: no server runtime on Pages.
+
+## Test plan
+
+- Contract tests validate deploy workflow contains:
+  - `pdoc` build step
+  - copy into `site/pydoc`
+- Validate Pages URL returns successful response after deploy:
+  - `https://ringxworld.github.io/story_generator/pydoc/`
+- Keep existing docs and demo deployment checks green.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ Latest ADR:
 
 - `0019-contract-registry-and-pipeline-governance.md`
 - `0020-pages-hosted-mkdocs-snapshot.md`
+- `0021-pages-hosted-python-api-reference.md`

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,6 +75,14 @@ When the API is running locally:
 - ReDoc: `http://127.0.0.1:8000/redoc`
 - OpenAPI JSON: `http://127.0.0.1:8000/openapi.json`
 
+## Hosted Python API reference (Pages)
+
+Static module reference pages are published to:
+
+- `https://ringxworld.github.io/story_generator/pydoc/`
+
+These pages are generated from Python source via `pdoc` during the Pages deploy workflow.
+
 Auth flow in Swagger UI:
 
 1. Call `POST /api/v1/auth/login`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,7 +3,7 @@
 ## Current split
 
 - GitHub Wiki: collaboration and project-operations notes
-- GitHub Pages: product-first static studio demo snapshot plus hosted docs under `/docs`
+- GitHub Pages: product-first static studio demo snapshot plus hosted docs under `/docs` and hosted Python API reference under `/pydoc`
 - React + TypeScript studio (`web/`): local dev now, static hosting ready
 - FastAPI service: local runtime today, external backend host later
 - Persistence: SQLite (`work/local/story_gen.db`) for local or single-instance deployments
@@ -70,10 +70,11 @@ S3-compatible note:
 
 1. Keep Pages focused on the product demo at repo root.
 2. Publish static docs snapshot on Pages under `/docs`.
-3. Keep docs mirrored into the repository wiki for collaborative edits.
-3. Keep API local-first for editing and workflow testing.
-4. Keep web studio and Python interface on one shared blueprint contract.
-5. Add CORS + stronger auth + storage migration when remote multi-user hosting is needed.
+3. Publish static Python API reference on Pages under `/pydoc`.
+4. Keep docs mirrored into the repository wiki for collaborative edits.
+5. Keep API local-first for editing and workflow testing.
+6. Keep web studio and Python interface on one shared blueprint contract.
+7. Add CORS + stronger auth + storage migration when remote multi-user hosting is needed.
 
 ## Wiki synchronization
 
@@ -89,6 +90,10 @@ Wiki URL:
 Hosted docs URL:
 
 - `https://ringxworld.github.io/story_generator/docs/`
+
+Hosted Python API reference URL:
+
+- `https://ringxworld.github.io/story_generator/pydoc/`
 
 ## Migration path
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,6 @@
 - Reference ingestion: `docs/reference_pipeline.md`
 - Native acceleration: `docs/native_cpp.md`
 - API stub: `docs/api.md`
+- Python API reference: `docs/python_api_reference.md`
 - Developer setup runbook: `docs/developer_setup.md`
 - Wiki sync guide: `docs/wiki_docs.md`

--- a/docs/python_api_reference.md
+++ b/docs/python_api_reference.md
@@ -1,0 +1,19 @@
+# Python API Reference
+
+`story_gen` publishes two API documentation surfaces:
+
+- Interactive HTTP API docs (local FastAPI runtime): `http://127.0.0.1:8000/docs`
+- Hosted Python module reference (GitHub Pages): `https://ringxworld.github.io/story_generator/pydoc/`
+
+The hosted Python reference is generated with `pdoc` during Pages deploy and is static.
+
+## Local generation
+
+From repository root:
+
+```bash
+uv run python tools/build_python_api_docs.py --output-dir pydoc_site
+```
+
+The helper script discovers all package modules under `src/story_gen/` and
+builds a complete static reference set.

--- a/docs/wiki_docs.md
+++ b/docs/wiki_docs.md
@@ -28,3 +28,4 @@ make wiki-sync-push
 - Wiki: `https://github.com/ringxworld/story_generator/wiki`
 - Product demo (Pages): `https://ringxworld.github.io/story_generator/`
 - Hosted docs (Pages): `https://ringxworld.github.io/story_generator/docs/`
+- Hosted Python API reference (Pages): `https://ringxworld.github.io/story_generator/pydoc/`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Architecture Diagrams: architecture_diagrams.md
   - Contracts Registry: contracts_registry.md
   - API: api.md
+  - Python API Reference: python_api_reference.md
   - Developer Setup: developer_setup.md
   - Good Essay Mode: essay_mode.md
   - Deployment: deployment.md
@@ -68,6 +69,7 @@ nav:
       - 0019 Contract Registry and Pipeline Governance: adr/0019-contract-registry-and-pipeline-governance.md
       - 0018 Wiki Docs + Product-First Pages: adr/0018-wiki-docs-and-product-first-pages.md
       - 0020 Pages Hosted MkDocs Snapshot: adr/0020-pages-hosted-mkdocs-snapshot.md
+      - 0021 Pages Hosted Python API Reference: adr/0021-pages-hosted-python-api-reference.md
   - Guides:
       - Dependency Charts: dependency_charts.md
       - Reference Pipeline: reference_pipeline.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ story-features = "story_gen.cli.features:main"
 [dependency-groups]
 dev = [
   "clang-format>=20.1.0",
+  "pdoc>=15.0.4",
   "pre-commit>=4.1.0",
   "mypy>=1.14.0",
   "mkdocs>=1.6.1",

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -97,6 +97,8 @@ def test_deploy_workflow_requires_ci_success() -> None:
     assert "uv sync --group dev" in workflow
     assert "Build docs snapshot" in workflow
     assert "uv run mkdocs build --strict --site-dir docs_site" in workflow
+    assert "Build Python API reference snapshot" in workflow
+    assert "uv run python tools/build_python_api_docs.py --output-dir pydoc_site" in workflow
     assert "Setup Node" in workflow
     assert "Build product demo snapshot" in workflow
     assert "VITE_BASE_PATH: /${{ github.event.repository.name }}/" in workflow
@@ -105,6 +107,8 @@ def test_deploy_workflow_requires_ci_success() -> None:
     assert "site/studio" in workflow
     assert "site/docs" in workflow
     assert "cp -R docs_site/. site/docs/" in workflow
+    assert "site/pydoc" in workflow
+    assert "cp -R pydoc_site/. site/pydoc/" in workflow
 
 
 def test_native_cmake_scaffold_present() -> None:
@@ -194,6 +198,7 @@ def test_mkdocs_configuration_exists() -> None:
     assert "Architecture Diagrams:" in config
     assert "Contracts Registry:" in config
     assert "API:" in config
+    assert "Python API Reference:" in config
     assert "Developer Setup:" in config
     assert "Good Essay Mode:" in config
     assert "Deployment:" in config
@@ -220,6 +225,7 @@ def test_mkdocs_configuration_exists() -> None:
     assert "0019 Contract Registry and Pipeline Governance:" in config
     assert "0018 Wiki Docs + Product-First Pages:" in config
     assert "0020 Pages Hosted MkDocs Snapshot:" in config
+    assert "0021 Pages Hosted Python API Reference:" in config
     assert "pymdownx.superfences" in config
     assert "mermaid.min.js" in config
     assert "javascripts/mermaid.js" in config
@@ -314,6 +320,7 @@ def test_architecture_docs_and_adr_scaffold_exist() -> None:
     assert (ROOT / "docs" / "adr" / "0015-dark-mode-default-and-toggle.md").exists()
     assert (ROOT / "docs" / "adr" / "0016-native-feature-metrics-acceleration-path.md").exists()
     assert (ROOT / "docs" / "adr" / "0017-story-bundle-binary-format.md").exists()
+    assert (ROOT / "docs" / "adr" / "0021-pages-hosted-python-api-reference.md").exists()
     assert (ROOT / "docs" / "adr" / "0019-contract-registry-and-pipeline-governance.md").exists()
     assert (ROOT / "docs" / "contracts_registry.md").exists()
     assert (ROOT / "docs" / "adr" / "0018-wiki-docs-and-product-first-pages.md").exists()
@@ -324,6 +331,7 @@ def test_architecture_docs_and_adr_scaffold_exist() -> None:
     assert (ROOT / "docs" / "developer_setup.md").exists()
     assert (ROOT / "docs" / "github_collaboration.md").exists()
     assert (ROOT / "docs" / "wiki_docs.md").exists()
+    assert (ROOT / "docs" / "python_api_reference.md").exists()
     assert (ROOT / "docs" / "essay_mode.md").exists()
     assert (ROOT / "docs" / "droplet_stack.md").exists()
     assert (ROOT / "docs" / "feature_pipeline.md").exists()
@@ -343,8 +351,22 @@ def test_api_docs_reference_swagger_and_openapi_endpoints() -> None:
     assert "http://127.0.0.1:8000/docs" in api_docs
     assert "http://127.0.0.1:8000/redoc" in api_docs
     assert "http://127.0.0.1:8000/openapi.json" in api_docs
+    assert "https://ringxworld.github.io/story_generator/pydoc/" in api_docs
     assert "Authorize" in api_docs
     assert "http://127.0.0.1:8000/redoc" in setup_docs
+
+
+def test_pyproject_dev_group_includes_python_api_docs_generator() -> None:
+    pyproject = _read("pyproject.toml")
+    assert '"pdoc>=' in pyproject
+
+
+def test_python_api_docs_builder_script_exists() -> None:
+    builder = _read("tools/build_python_api_docs.py")
+    assert "def _discover_modules" in builder
+    assert "python tools/build_python_api_docs.py --output-dir pydoc_site" in _read(
+        ".github/workflows/deploy-pages.yml"
+    )
 
 
 def test_analysis_contract_scaffold_exists_and_is_valid_json() -> None:

--- a/tools/build_python_api_docs.py
+++ b/tools/build_python_api_docs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Build static Python API reference pages with pdoc."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _discover_modules(src_root: Path) -> list[str]:
+    modules: list[str] = [src_root.name]
+    for path in sorted(src_root.rglob("*.py")):
+        relative = path.relative_to(src_root.parent)
+        module_parts = list(relative.with_suffix("").parts)
+        if module_parts[-1] in {"__init__", "__main__"}:
+            continue
+        modules.append(".".join(module_parts))
+    deduped = list(dict.fromkeys(modules))
+    if not deduped:
+        raise RuntimeError("No Python modules discovered for pdoc generation.")
+    return deduped
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build pdoc pages for story_gen modules.")
+    parser.add_argument(
+        "--src-root",
+        type=Path,
+        default=Path("src/story_gen"),
+        help="Path to package source root.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("pydoc_site"),
+        help="Directory to write generated HTML docs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    src_root = args.src_root.resolve()
+    output_dir = args.output_dir.resolve()
+    repo_root = src_root.parents[1]
+
+    modules = _discover_modules(src_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    src_path = str(repo_root / "src")
+    env["PYTHONPATH"] = (
+        src_path if not env.get("PYTHONPATH") else f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+
+    command = [sys.executable, "-m", "pdoc", "-o", str(output_dir), *modules]
+    subprocess.run(command, check=True, cwd=repo_root, env=env)
+
+    index_path = output_dir / "index.html"
+    root_page = output_dir / "story_gen.html"
+    if not index_path.exists() and root_page.exists():
+        index_path.write_text(root_page.read_text(encoding="utf-8"), encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/e7/b47792cc2d01c7e1d37c32402182524774dadd2d26339bd224e0e913832e/cuda_bindings-12.9.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c912a3d9e6b6651853eed8eed96d6800d69c08e94052c292fec3f282c5a817c9", size = 12210593, upload-time = "2025-10-21T14:51:36.574Z" },
@@ -792,6 +792,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/b1/af95bcae8549f1f3fd70faacb29075826a0d689a27f232e8cee315efa053/markdown-3.10.1.tar.gz", hash = "sha256:1c19c10bd5c14ac948c53d0d762a04e2fa35a6d58a6b7b1e6bfcbe6fefc0001a", size = 365402, upload-time = "2026-01-21T18:09:28.206Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/1b/6ef961f543593969d25b2afe57a3564200280528caa9bd1082eecdd7b3bc/markdown-3.10.1-py3-none-any.whl", hash = "sha256:867d788939fe33e4b736426f5b9f651ad0c0ae0ecf89df0ca5d1176c70812fe3", size = 107684, upload-time = "2026-01-21T18:09:27.203Z" },
+]
+
+[[package]]
+name = "markdown2"
+version = "2.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/f8/b2ae8bf5f28f9b510ae097415e6e4cb63226bb28d7ee01aec03a755ba03b/markdown2-2.5.4.tar.gz", hash = "sha256:a09873f0b3c23dbfae589b0080587df52ad75bb09a5fa6559147554736676889", size = 145652, upload-time = "2025-07-27T16:16:24.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/06/2697b5043c3ecb720ce0d243fc7cf5024c0b5b1e450506e9b21939019963/markdown2-2.5.4-py3-none-any.whl", hash = "sha256:3c4b2934e677be7fec0e6f2de4410e116681f4ad50ec8e5ba7557be506d3f439", size = 49954, upload-time = "2025-07-27T16:16:23.026Z" },
 ]
 
 [[package]]
@@ -1232,7 +1241,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1243,7 +1252,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1270,9 +1279,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1283,7 +1292,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1414,6 +1423,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pdoc"
+version = "16.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown2" },
+    { name = "markupsafe" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/fe/ab3f34a5fb08c6b698439a2c2643caf8fef0d61a86dd3fdcd5501c670ab8/pdoc-16.0.0.tar.gz", hash = "sha256:fdadc40cc717ec53919e3cd720390d4e3bcd40405cb51c4918c119447f913514", size = 111890, upload-time = "2025-10-27T16:02:16.345Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/a1/56a17b7f9e18c2bb8df73f3833345d97083b344708b97bab148fdd7e0b82/pdoc-16.0.0-py3-none-any.whl", hash = "sha256:070b51de2743b9b1a4e0ab193a06c9e6c12cf4151cf9137656eebb16e8556628", size = 100014, upload-time = "2025-10-27T16:02:15.007Z" },
 ]
 
 [[package]]
@@ -2319,6 +2343,7 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mypy" },
+    { name = "pdoc" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2352,6 +2377,7 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.19" },
     { name = "mypy", specifier = ">=1.14.0" },
+    { name = "pdoc", specifier = ">=15.0.4" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary
Publish hosted Python API reference pages on GitHub Pages so demo + technical docs + Python module docs are all available from one static surface.

## Linked Issues
- Closes https://github.com/ringxworld/story_generator/issues/104

## Compact Mode (Small/Low-Risk Change)
### Change Notes
- Added Pages deploy build step for Python API reference output under `/pydoc/`.
- Added `tools/build_python_api_docs.py` to generate complete module docs (not package root only).
- Added docs links and a new `docs/python_api_reference.md` page.
- Added ADR `0021` and contract tests to enforce deploy/docs behavior.

### Validation
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run mkdocs build --strict`
- `uv run python tools/build_python_api_docs.py --output-dir pydoc_site`