### PR TITLE
Fix escaped newline issue formatting and add hygiene checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,3 +295,6 @@ clean:
 
 clean-deep: clean
 	$(RUN) python -c "import shutil; [shutil.rmtree(p, ignore_errors=True) for p in ['.venv', 'web/node_modules']]"
+
+issue-body-hygiene:
+	$(RUN) python tools/issue_body_hygiene.py --repo $(PROJECT_OWNER)/$(PROJECT_REPO) --state all

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -122,3 +122,18 @@ Manual rename fallback:
   `Motivation / Context`, `What Changed`, `Tradeoffs and Risks`, `How This Was Tested`
   - compact mode:
   `Change Notes`, `Validation`
+
+## Issue body formatting guardrail
+
+When creating issues from automation or shell commands, prefer a body file over inline escaped strings:
+
+```bash
+gh issue create --repo ringxworld/story_generator --title "..." --body-file work/issue-body.md
+```
+
+If issue markdown was posted with literal `\\n` sequences, run:
+
+```bash
+uv run python tools/issue_body_hygiene.py --repo ringxworld/story_generator --state all
+uv run python tools/issue_body_hygiene.py --repo ringxworld/story_generator --issues 104 106 108 --apply
+```

--- a/tests/test_issue_body_hygiene.py
+++ b/tests/test_issue_body_hygiene.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "tools" / "issue_body_hygiene.py"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location("issue_body_hygiene", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_detects_escaped_newline_issue_body() -> None:
+    module = _load_module()
+    body = "## Summary\\nLine one\\n\\n## Acceptance\\n- Item"
+    assert module.has_escaped_newline_formatting(body) is True
+
+
+def test_ignores_normal_markdown_newlines() -> None:
+    module = _load_module()
+    body = "## Summary\nLine one\n\n## Acceptance\n- Item"
+    assert module.has_escaped_newline_formatting(body) is False
+
+
+def test_normalize_issue_body_rewrites_literals() -> None:
+    module = _load_module()
+    raw = "## Summary\\nLine one\\n\\n## Acceptance\\n- Item"
+    normalized = module.normalize_issue_body(raw)
+    assert normalized == "## Summary\nLine one\n\n## Acceptance\n- Item\n"
+
+
+def test_plan_issue_fixes_only_returns_malformed_issues() -> None:
+    module = _load_module()
+    issues = [
+        module.IssueRecord(
+            number=104,
+            title="Broken",
+            state="OPEN",
+            body="## Summary\\nBroken body",
+            url="https://example.invalid/104",
+        ),
+        module.IssueRecord(
+            number=105,
+            title="Good",
+            state="OPEN",
+            body="## Summary\nGood body",
+            url="https://example.invalid/105",
+        ),
+    ]
+
+    fixes = module.plan_issue_fixes(issues)
+
+    assert len(fixes) == 1
+    assert fixes[0].issue.number == 104
+    assert "\\n" not in fixes[0].normalized_body

--- a/tools/issue_body_hygiene.py
+++ b/tools/issue_body_hygiene.py
@@ -1,0 +1,267 @@
+"""Detect and repair escaped-newline formatting in GitHub issue bodies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_GH_PATH = Path(r"C:\Program Files\GitHub CLI\gh.exe")
+
+
+class IssueBodyHygieneError(RuntimeError):
+    """Raised when issue body hygiene operations fail."""
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    number: int
+    title: str
+    state: str
+    body: str
+    url: str
+
+
+@dataclass(frozen=True)
+class IssueFix:
+    issue: IssueRecord
+    normalized_body: str
+
+
+def _resolve_gh_binary() -> str:
+    if configured := os.environ.get("GH_BIN"):
+        candidate = Path(configured)
+        if candidate.exists():
+            return str(candidate)
+        raise IssueBodyHygieneError(f"GH_BIN points to missing executable: {candidate}")
+    if found := shutil.which("gh"):
+        return found
+    if os.name == "nt" and WINDOWS_GH_PATH.exists():
+        return str(WINDOWS_GH_PATH)
+    raise IssueBodyHygieneError("GitHub CLI executable not found. Install `gh` or set GH_BIN.")
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    completed = subprocess.run(
+        [_resolve_gh_binary(), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or completed.stdout.strip() or "gh command failed"
+        raise IssueBodyHygieneError(message)
+    return json.loads(completed.stdout)
+
+
+def _run_gh(args: list[str]) -> None:
+    completed = subprocess.run(
+        [_resolve_gh_binary(), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or completed.stdout.strip() or "gh command failed"
+        raise IssueBodyHygieneError(message)
+
+
+def has_escaped_newline_formatting(body: str) -> bool:
+    if "\\n" not in body and "\\r\\n" not in body:
+        return False
+
+    literal_count = body.count("\\n") + body.count("\\r\\n")
+    real_count = body.count("\n")
+    has_template_signals = "## " in body and "\\n" in body
+    has_list_signals = "\\n- " in body
+
+    if real_count == 0:
+        return True
+    if literal_count >= real_count and (has_template_signals or has_list_signals):
+        return True
+    return False
+
+
+def normalize_issue_body(body: str) -> str:
+    normalized = body.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\r\n", "\n")
+    normalized = "\n".join(line.rstrip() for line in normalized.split("\n"))
+    return normalized.strip() + "\n"
+
+
+def collect_issues(
+    *, repo: str, issue_numbers: list[int], state: str, limit: int
+) -> list[IssueRecord]:
+    if issue_numbers:
+        issues: list[IssueRecord] = []
+        for number in issue_numbers:
+            payload = cast(
+                dict[str, Any],
+                _run_gh_json(
+                    [
+                        "issue",
+                        "view",
+                        str(number),
+                        "--repo",
+                        repo,
+                        "--json",
+                        "number,title,state,body,url",
+                    ]
+                ),
+            )
+            issues.append(
+                IssueRecord(
+                    number=int(payload["number"]),
+                    title=str(payload.get("title", "")),
+                    state=str(payload.get("state", "")),
+                    body=str(payload.get("body", "")),
+                    url=str(payload.get("url", "")),
+                )
+            )
+        return issues
+
+    payload = cast(
+        list[dict[str, Any]],
+        _run_gh_json(
+            [
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                state,
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,state,body,url",
+            ]
+        ),
+    )
+    return [
+        IssueRecord(
+            number=int(item["number"]),
+            title=str(item.get("title", "")),
+            state=str(item.get("state", "")),
+            body=str(item.get("body", "")),
+            url=str(item.get("url", "")),
+        )
+        for item in payload
+    ]
+
+
+def plan_issue_fixes(issues: list[IssueRecord]) -> list[IssueFix]:
+    fixes: list[IssueFix] = []
+    for issue in issues:
+        if not has_escaped_newline_formatting(issue.body):
+            continue
+        normalized = normalize_issue_body(issue.body)
+        if normalized == issue.body:
+            continue
+        fixes.append(IssueFix(issue=issue, normalized_body=normalized))
+    return fixes
+
+
+def apply_issue_fixes(*, repo: str, fixes: list[IssueFix]) -> None:
+    for fix in fixes:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=".md", delete=False
+        ) as handle:
+            temp_path = Path(handle.name)
+            handle.write(fix.normalized_body)
+        try:
+            _run_gh(
+                [
+                    "issue",
+                    "edit",
+                    str(fix.issue.number),
+                    "--repo",
+                    repo,
+                    "--body-file",
+                    str(temp_path),
+                ]
+            )
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Detect/repair escaped-newline issue body formatting."
+    )
+    parser.add_argument("--repo", required=True, help="Repository in owner/repo format.")
+    parser.add_argument(
+        "--issues", nargs="*", type=int, default=[], help="Issue numbers to inspect."
+    )
+    parser.add_argument(
+        "--state",
+        default="all",
+        choices=("open", "closed", "all"),
+        help="Issue state when scanning via issue list.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=200, help="Max issues to scan when --issues is omitted."
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Apply fixes in-place on GitHub issues."
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text", help="Output format.")
+    return parser
+
+
+def _print_text(*, fixes: list[IssueFix], applied: bool) -> None:
+    mode = "applied" if applied else "dry-run"
+    print(f"Issue body hygiene ({mode})")
+    print("========================")
+    print(f"fixes: {len(fixes)}")
+    for fix in fixes:
+        print(f"- #{fix.issue.number} {fix.issue.title}")
+
+
+def _print_json(*, fixes: list[IssueFix], applied: bool) -> None:
+    payload = {
+        "mode": "applied" if applied else "dry-run",
+        "fixes": [
+            {
+                "number": fix.issue.number,
+                "title": fix.issue.title,
+                "state": fix.issue.state,
+                "url": fix.issue.url,
+            }
+            for fix in fixes
+        ],
+    }
+    print(json.dumps(payload, indent=2))
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    issues = collect_issues(
+        repo=args.repo, issue_numbers=args.issues, state=args.state, limit=args.limit
+    )
+    fixes = plan_issue_fixes(issues)
+
+    if args.apply and fixes:
+        apply_issue_fixes(repo=args.repo, fixes=fixes)
+
+    if args.format == "json":
+        _print_json(fixes=fixes, applied=args.apply)
+    else:
+        _print_text(fixes=fixes, applied=args.apply)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except IssueBodyHygieneError as error:
+        print(error)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary
Fixes issue body markdown corruption caused by literal escaped newlines (`\\n`) being passed into `gh issue create`.

## Linked Issues
- Closes https://github.com/ringxworld/story_generator/issues/110

### Motivation / Context
Issue templates were rendering as one long line in some automation paths. That made issue content harder to review and broke the audit trail readability.

### What Changed
- Added `tools/issue_body_hygiene.py` to detect and normalize malformed issue bodies.
- Added unit tests in `tests/test_issue_body_hygiene.py` for detection and normalization behavior.
- Added `make issue-body-hygiene` and usage guidance in `docs/github_collaboration.md`.
- Repaired existing malformed issue bodies directly on GitHub (`#104`, `#106`, `#108`).

### Tradeoffs and Risks
The script uses GitHub CLI and writes updates to issue bodies when `--apply` is used. That is intentional and scoped, but still a mutating operation.

### How This Was Tested
- `uv run pre-commit run --all-files`
- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run mkdocs build --strict`
