### PR TITLE
Enforce feature-branch PR workflow and right-size README logo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,19 @@ After each completed prompt:
 1. implement
 2. validate
 3. commit
-4. push to `origin/main`
+4. push feature branch
+5. open PR to `develop`
+6. merge via PR after required checks pass
+
+## 7.1 Branch and PR Discipline
+
+This repository is PR-first and feature-branch-only for agent work:
+
+- Always branch from latest `origin/develop` before making changes.
+- Never commit directly to `develop` or `main`.
+- Keep changes isolated to one human-readable feature branch per task.
+- After pushing, open/update a PR to `develop` and link the relevant issue URL.
+- Do not close implementation issues until the PR is merged.
 
 ## 8. Human-Facing Wording for Issues and PRs
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # story_gen
 
-![story_gen logo](docs/assets/brand/story-gen-mark.svg)
+<img src="docs/assets/brand/story-gen-mark.svg" alt="story_gen logo" width="180">
 
 [![CI](https://github.com/ringxworld/story_generator/actions/workflows/ci.yml/badge.svg)](https://github.com/ringxworld/story_generator/actions/workflows/ci.yml)
 [![Deploy Pages](https://github.com/ringxworld/story_generator/actions/workflows/deploy-pages.yml/badge.svg)](https://github.com/ringxworld/story_generator/actions/workflows/deploy-pages.yml)


### PR DESCRIPTION
## Summary
This updates agent operating rules to require feature-branch + PR flow, and scales the README logo to a reasonable fixed width.

## Linked Issues
- Closes https://github.com/ringxworld/story_generator/issues/114

### Change Notes
- Updated `AGENTS.md` completion flow to push feature branch, open PR to `develop`, and merge via PR.
- Added an explicit `Branch and PR Discipline` section with non-negotiable branch rules.
- Switched README logo rendering to HTML with width control (`width="180"`).

### Validation
- `uv run pre-commit run --files AGENTS.md README.md`
