### PR TITLE
Add live-stack E2E coverage for analysis and dashboard API flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,25 @@ jobs:
       - name: Docs build
         run: uv run mkdocs build --strict
 
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Live-stack E2E (analysis + dashboard)
+        run: uv run pytest tests/test_e2e_stack.py -q --no-cov
+
   frontend:
     runs-on: ubuntu-latest
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ test:
 	$(RUN) pytest
 
 e2e:
-	$(RUN) pytest tests/test_e2e_stack.py
+	$(RUN) pytest tests/test_e2e_stack.py --no-cov
 
 coverage: test
 

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -77,6 +77,9 @@ def test_ci_workflow_includes_code_quality_steps() -> None:
     assert "Upload story QA evaluation summary" in workflow
     assert "story-qa-evaluation-summary" in workflow
     assert "uv run mkdocs build --strict" in workflow
+    assert "e2e:" in workflow
+    assert "Live-stack E2E (analysis + dashboard)" in workflow
+    assert "uv run pytest tests/test_e2e_stack.py -q --no-cov" in workflow
     assert "uv run python tools/check_imports.py" in workflow
     assert "uv run python tools/check_contract_drift.py" in workflow
     assert "Configure CMake" in workflow


### PR DESCRIPTION
## Summary
Add live-stack E2E coverage for the story-analysis and dashboard API path so CI validates the full HTTP flow (analysis run through dashboard projections and exports) against a running API process.

## Linked Issues
- Closes https://github.com/ringxworld/story_generator/issues/120

## Compact Mode (Small/Low-Risk Change)
### Change Notes
- Expanded `tests/test_e2e_stack.py` with a new process-level E2E that executes:
  - `POST /api/v1/stories/{story_id}/analysis/run`
  - `GET /api/v1/stories/{story_id}/dashboard/overview`
  - `GET /api/v1/stories/{story_id}/dashboard/timeline`
  - `GET /api/v1/stories/{story_id}/dashboard/themes/heatmap`
  - `GET /api/v1/stories/{story_id}/dashboard/arcs`
  - `GET /api/v1/stories/{story_id}/dashboard/graph`
  - `GET /api/v1/stories/{story_id}/dashboard/drilldown/{item_id}`
  - one SVG export and one PNG export endpoint
- Added deterministic export assertions on repeated calls:
  - timeline SVG payload equality
  - graph PNG base64 equality
- Added live-stack auth boundary checks for dashboard route access:
  - unauthenticated request returns `401`
  - cross-user owner-isolated request returns `404`
- Added a dedicated CI `e2e` job in `.github/workflows/ci.yml` that runs `tests/test_e2e_stack.py` with `--no-cov`.
- Updated `Makefile` `e2e` target to use `--no-cov` for deterministic standalone execution.
- Extended `tests/test_project_contracts.py` so workflow contract checks enforce the dedicated E2E job.

### Validation
- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run pytest tests/test_e2e_stack.py tests/test_project_contracts.py -q --no-cov`
- `uv run pre-commit run --all-files`
- `uv run mkdocs build --strict`