### PR TITLE
Fix API docs with OpenAPI snapshot + hosted schema reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Contract drift check
         run: uv run python tools/check_contract_drift.py
 
+      - name: OpenAPI snapshot drift check
+        run: uv run python tools/export_openapi_snapshot.py --check
+
       - name: Lockfile check
         run: uv lock --check
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,7 +46,9 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Build docs snapshot
-        run: uv run mkdocs build --strict --site-dir docs_site
+        run: |
+          uv run python tools/export_openapi_snapshot.py
+          uv run mkdocs build --strict --site-dir docs_site
 
       - name: Build Python API reference snapshot
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ This repository is PR-first and feature-branch-only for agent work:
 
 - Always branch from latest `origin/develop` before making changes.
 - Never commit directly to `develop` or `main`.
+- If work is started on `main`, immediately move the changes to a feature branch from `develop`.
 - Keep changes isolated to one human-readable feature branch per task.
 - After pushing, open/update a PR to `develop` and link the relevant issue URL.
 - Do not close implementation issues until the PR is merged.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ISSUE_SUMMARY_FILE ?=.github/ISSUE_CLOSE_SUMMARY_TEMPLATE.md
 
 .DEFAULT_GOAL := help
 
-.PHONY: help sync hooks-install hooks-run lock-check import-check contracts-check lint fix format format-check typecheck test e2e coverage quality frontend-quality native-quality check story pipeline-canary qa-eval build-site docs-serve story-page reference reference-translate collect-story video-story api blueprint features dev-stack dev-stack-hot stack-up stack-up-hot brand-icons docker-build docker-up docker-up-detached attach docker-down docker-logs docker-ci web-install web-dev web-hot web-typecheck web-test web-coverage web-build cpp-configure cpp-build cpp-test cpp-demo cpp-format cpp-format-check cpp-cppcheck wiki-sync wiki-sync-push contracts-export project-sync project-audit label-audit issue-close pr-open pr-checks pr-merge pr-auto deploy clean clean-deep
+.PHONY: help sync hooks-install hooks-run lock-check import-check contracts-check openapi-export openapi-check lint fix format format-check typecheck test e2e coverage quality frontend-quality native-quality check story pipeline-canary qa-eval build-site docs-serve story-page reference reference-translate collect-story video-story api blueprint features dev-stack dev-stack-hot stack-up stack-up-hot brand-icons docker-build docker-up docker-up-detached attach docker-down docker-logs docker-ci web-install web-dev web-hot web-typecheck web-test web-coverage web-build cpp-configure cpp-build cpp-test cpp-demo cpp-format cpp-format-check cpp-cppcheck wiki-sync wiki-sync-push contracts-export project-sync project-audit label-audit issue-close pr-open pr-checks pr-merge pr-auto deploy clean clean-deep
 
 help:
 	@echo "story_gen targets:"
@@ -29,6 +29,8 @@ help:
 	@echo "  make lock-check           - verify uv.lock matches pyproject constraints"
 	@echo "  make import-check         - enforce Python import layer boundaries"
 	@echo "  make contracts-check      - validate contract registry + stage contract drift"
+	@echo "  make openapi-export       - generate docs OpenAPI snapshot from FastAPI app"
+	@echo "  make openapi-check        - fail when OpenAPI snapshot is stale"
 	@echo "  make lint                 - run ruff checks"
 	@echo "  make fix                  - auto-fix lint issues and format code"
 	@echo "  make format               - format code with ruff"
@@ -113,6 +115,12 @@ import-check:
 contracts-check:
 	$(RUN) python tools/check_contract_drift.py
 
+openapi-export:
+	$(RUN) python tools/export_openapi_snapshot.py
+
+openapi-check:
+	$(RUN) python tools/export_openapi_snapshot.py --check
+
 lint:
 	$(RUN) ruff check .
 
@@ -137,7 +145,7 @@ e2e:
 
 coverage: test
 
-quality: lock-check import-check contracts-check lint format-check typecheck test
+quality: lock-check import-check contracts-check openapi-check lint format-check typecheck test
 
 frontend-quality: web-typecheck web-coverage web-build
 
@@ -155,9 +163,11 @@ qa-eval:
 	$(RUN) story-qa-eval --strict --output work/qa/evaluation_summary.json
 
 build-site:
+	$(RUN) python tools/export_openapi_snapshot.py
 	$(RUN) mkdocs build --strict
 
 docs-serve:
+	$(RUN) python tools/export_openapi_snapshot.py
 	$(RUN) mkdocs serve
 
 story-page:

--- a/docs/adr/0030-openapi-snapshot-and-hosted-api-reference.md
+++ b/docs/adr/0030-openapi-snapshot-and-hosted-api-reference.md
@@ -1,0 +1,61 @@
+# ADR 0030: OpenAPI Snapshot and Hosted API Reference
+
+## Status
+
+Accepted
+
+## Problem
+
+The repository exposed live Swagger/ReDoc only when FastAPI was running locally.
+Hosted docs on GitHub Pages did not provide a schema-driven API reference, which
+made API docs look incomplete or stale compared to runtime surfaces.
+
+## Non-goals
+
+- Hosting live FastAPI Swagger/ReDoc directly on GitHub Pages.
+- Replacing local interactive `/docs` and `/redoc` endpoints.
+- Replacing the existing Python module reference published under `/pydoc/`.
+
+## Decision
+
+Generate and commit a deterministic OpenAPI snapshot from `create_app().openapi()`
+and use that snapshot as the source for hosted API docs.
+
+Implementation shape:
+
+- Add `tools/export_openapi_snapshot.py` to export/check schema snapshots.
+- Store snapshot at `docs/assets/openapi/story_gen.openapi.json`.
+- Render snapshot in `docs/api.md` using ReDoc for hosted static browsing.
+- Enforce drift checks in CI and pre-push workflows.
+- Regenerate snapshot before Pages docs build.
+
+## Public API
+
+- New hosted static OpenAPI artifact:
+  - `/docs/assets/openapi/story_gen.openapi.json`
+- `docs/api.md` becomes schema-driven using the exported OpenAPI snapshot.
+- New developer commands:
+  - `make openapi-export`
+  - `make openapi-check`
+
+## Invariants
+
+- Runtime Swagger (`/docs`) and runtime OpenAPI (`/openapi.json`) remain authoritative
+  while API is running locally.
+- Hosted Pages docs remain static-only and do not execute backend routes.
+- OpenAPI snapshot must match generated schema from current code.
+
+## Test Plan
+
+- Add unit test to assert committed snapshot equals `create_app().openapi()`.
+- Add contract tests for:
+  - Make targets (`openapi-export`, `openapi-check`)
+  - CI step (`tools/export_openapi_snapshot.py --check`)
+  - Pages deploy step (`tools/export_openapi_snapshot.py`)
+- Run full repository quality gates before merge.
+
+## Consequences
+
+- API docs quality and discoverability improve on hosted docs without backend hosting.
+- Schema drift is now explicit and blocked by CI/pre-push checks.
+- Developers must regenerate the snapshot when API contracts change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ Latest ADR:
 - `0027-pipeline-ingestion-resilience-and-canary.md`
 - `0028-qa-evaluation-harness-and-calibration-gates.md`
 - `0029-nlp-provider-resilience-and-insight-calibration.md`
+- `0030-openapi-snapshot-and-hosted-api-reference.md`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,142 +1,70 @@
 # API
 
-The HTTP API provides authenticated local-preview story editing backed by SQLite.
+The HTTP API is defined by FastAPI and exported as OpenAPI.
 
-## Run locally
+## Source of Truth
+
+- Runtime Swagger UI (interactive): `http://127.0.0.1:8000/docs`
+- Runtime ReDoc (interactive): `http://127.0.0.1:8000/redoc`
+- Runtime OpenAPI JSON: `http://127.0.0.1:8000/openapi.json`
+- Hosted static OpenAPI JSON (Pages docs snapshot): `https://ringxworld.github.io/story_generator/docs/assets/openapi/story_gen.openapi.json`
+
+## Hosted API Reference (Static)
+
+The docs site renders the exported OpenAPI schema using ReDoc:
+
+<div id="redoc-container"></div>
+<script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+<script>
+  const specUrl = new URL('../assets/openapi/story_gen.openapi.json', window.location.href).toString();
+  Redoc.init(specUrl, {
+    expandResponses: '200,201',
+    hideDownloadButton: false,
+    sortPropsAlphabetically: true
+  }, document.getElementById('redoc-container'));
+</script>
+
+## Local run
 
 ```bash
 uv run story-api --host 127.0.0.1 --port 8000 --reload
 ```
 
-Choose a custom DB path:
+Custom database path:
 
 ```bash
 uv run story-api --db-path work/local/story_gen.db
 ```
 
-## Endpoints
+## Authentication in Swagger UI
 
-- `GET /healthz`
-  - Returns service health payload.
-- `GET /api/v1`
-  - Returns API stage metadata and endpoint list.
-- `POST /api/v1/auth/register`
-  - Registers a local user account.
-- `POST /api/v1/auth/login`
-  - Returns bearer token for subsequent requests.
-- `GET /api/v1/me`
-  - Returns authenticated user profile.
-- `GET /api/v1/stories?limit=<n>`
-  - Lists stories for the authenticated owner.
-- `POST /api/v1/stories`
-  - Creates one story blueprint for authenticated owner.
-- `GET /api/v1/stories/{story_id}`
-  - Reads one owner-scoped story.
-- `PUT /api/v1/stories/{story_id}`
-  - Updates title/blueprint for one owner-scoped story.
-- `POST /api/v1/stories/{story_id}/features/extract`
-  - Runs story-first chapter feature extraction and persists a new run.
-- `GET /api/v1/stories/{story_id}/features/latest`
-  - Returns latest persisted extraction result for that story.
-- `POST /api/v1/stories/{story_id}/analysis/run`
-  - Runs deterministic story intelligence analysis (ingestion, translation, beats, themes, timeline, insights).
-- `GET /api/v1/stories/{story_id}/analysis/latest`
-  - Returns latest persisted analysis run summary for that story.
-- `GET /api/v1/stories/{story_id}/dashboard/overview`
-  - Returns big-picture card payload for dashboard.
-- `GET /api/v1/stories/{story_id}/dashboard/v1/overview`
-  - Versioned alias of dashboard overview payload for frontend contract pinning.
-- `GET /api/v1/stories/{story_id}/dashboard/timeline`
-  - Returns timeline lane payloads for actual-time and narrative-order views.
-- `GET /api/v1/stories/{story_id}/dashboard/v1/timeline`
-  - Versioned alias of timeline lane payloads.
-- `GET /api/v1/stories/{story_id}/dashboard/timeline/export.svg`
-  - Returns deterministic SVG export payload for timeline lanes.
-- `GET /api/v1/stories/{story_id}/dashboard/timeline/export.png`
-  - Returns deterministic PNG export payload (`png_base64`) for timeline lanes.
-- `GET /api/v1/stories/{story_id}/dashboard/themes/heatmap`
-  - Returns theme-by-stage intensity cells.
-- `GET /api/v1/stories/{story_id}/dashboard/v1/themes/heatmap`
-  - Versioned alias of theme heatmap payload.
-- `GET /api/v1/stories/{story_id}/dashboard/themes/heatmap/export.svg`
-  - Returns deterministic SVG export payload for theme heatmaps.
-- `GET /api/v1/stories/{story_id}/dashboard/themes/heatmap/export.png`
-  - Returns deterministic PNG export payload (`png_base64`) for theme heatmaps.
-- `GET /api/v1/stories/{story_id}/dashboard/arcs`
-  - Returns arc chart points (character/conflict/emotion lanes).
-- `GET /api/v1/stories/{story_id}/dashboard/drilldown/{item_id}`
-  - Returns detail payload for one drilldown item.
-- `GET /api/v1/stories/{story_id}/dashboard/graph`
-  - Returns graph nodes/edges for interactive rendering.
-- `GET /api/v1/stories/{story_id}/dashboard/graph/export.svg`
-  - Returns SVG export payload for graph image use.
-- `GET /api/v1/stories/{story_id}/dashboard/graph/export.png`
-  - Returns deterministic PNG export payload (`png_base64`) for graph image use.
-- `GET /api/v1/essays?limit=<n>`
-  - Lists essays for the authenticated owner.
-- `POST /api/v1/essays`
-  - Creates one essay workspace with `EssayBlueprint` and optional draft text.
-- `GET /api/v1/essays/{essay_id}`
-  - Reads one owner-scoped essay.
-- `PUT /api/v1/essays/{essay_id}`
-  - Updates title/blueprint/draft for one owner-scoped essay.
-- `POST /api/v1/essays/{essay_id}/evaluate`
-  - Runs deterministic quality checks for "good essay mode" and returns pass/fail findings.
-
-## Interactive API docs (Swagger)
-
-When the API is running locally:
-
-- Swagger UI: `http://127.0.0.1:8000/docs`
-- ReDoc: `http://127.0.0.1:8000/redoc`
-- OpenAPI JSON: `http://127.0.0.1:8000/openapi.json`
-
-## Hosted Python API reference (Pages)
-
-Static module reference pages are published to:
-
-- `https://ringxworld.github.io/story_generator/pydoc/`
-
-These pages are generated from Python source via `pdoc` during the Pages deploy workflow.
-
-## Dashboard Drilldown Payload Shape
-
-`GET /api/v1/stories/{story_id}/dashboard/drilldown/{item_id}` returns:
-
-- `item_id`: stable drilldown item key (for example `theme:<theme_id>`).
-- `item_type`: one of `insight:*`, `theme`, `arc`, `conflict`, `emotion`.
-- `title`: short display title for panel header.
-- `content`: narrative detail text for selected item.
-- `evidence_segment_ids`: ordered segment ids backing the drilldown claim.
-
-Auth flow in Swagger UI:
-
-1. Call `POST /api/v1/auth/login`.
-2. Copy `access_token` from the response.
+1. Call `POST /api/v1/auth/register` or use an existing account.
+2. Call `POST /api/v1/auth/login` and copy `access_token`.
 3. Click **Authorize** in Swagger UI and paste `Bearer <token>`.
-4. Execute authenticated routes (`/stories/*`, `/essays/*`).
+4. Execute owner-scoped routes (`/stories/*`, `/essays/*`).
+
+## Keep docs current
+
+Generate the committed OpenAPI snapshot used by docs:
+
+```bash
+make openapi-export
+```
+
+Check for schema drift in CI/local gates:
+
+```bash
+make openapi-check
+```
+
+## Python API docs
+
+Python module docs are published separately:
+
+- Hosted Python API reference: `https://ringxworld.github.io/story_generator/pydoc/`
+- Local build: `uv run python tools/build_python_api_docs.py --output-dir pydoc_site`
 
 ## Notes
 
-- OpenAPI docs are available at `/docs` when running locally.
-- Default local DB path is `work/local/story_gen.db`.
-- Auth is bearer-token based for local/dev workflows.
-- Dashboard and analysis endpoints are owner-scoped and require a prior analysis run.
-- This API is intended for local/dev now and backend hosting later.
-- GitHub Pages is static hosting only, so it can serve docs/front-end but not this Python API.
-- Python users can work with the same contracts via `story_gen.api` and `story-blueprint`.
-- Override allowed CORS origins with `STORY_GEN_CORS_ORIGINS` (comma-separated).
-
-## Dashboard export CLI
-
-Export the latest owner-scoped dashboard graph from SQLite:
-
-```bash
-uv run story-dashboard-export \
-  --db-path work/local/story_gen.db \
-  --story-id <story-id> \
-  --owner-id <owner-id> \
-  --view timeline \
-  --format png \
-  --output work/exports/<story-id>-timeline.png
-```
+- GitHub Pages is static hosting and cannot run live FastAPI routes.
+- The interactive Swagger/ReDoc surfaces require a running API process.

--- a/docs/assets/openapi/story_gen.openapi.json
+++ b/docs/assets/openapi/story_gen.openapi.json
@@ -1,0 +1,3319 @@
+{
+  "components": {
+    "schemas": {
+      "ApiRootResponse": {
+        "description": "Describes currently available API capabilities and runtime mode.",
+        "properties": {
+          "auth": {
+            "const": "bearer-token",
+            "default": "bearer-token",
+            "title": "Auth",
+            "type": "string"
+          },
+          "endpoints": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Endpoints",
+            "type": "array"
+          },
+          "name": {
+            "default": "story_gen",
+            "title": "Name",
+            "type": "string"
+          },
+          "persistence": {
+            "const": "sqlite",
+            "default": "sqlite",
+            "title": "Persistence",
+            "type": "string"
+          },
+          "stage": {
+            "const": "local-preview",
+            "default": "local-preview",
+            "title": "Stage",
+            "type": "string"
+          }
+        },
+        "title": "ApiRootResponse",
+        "type": "object"
+      },
+      "AuthLoginRequest": {
+        "additionalProperties": false,
+        "description": "Authenticate and request an access token.",
+        "properties": {
+          "email": {
+            "maxLength": 320,
+            "minLength": 5,
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "format": "password",
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "AuthLoginRequest",
+        "type": "object"
+      },
+      "AuthRegisterRequest": {
+        "additionalProperties": false,
+        "description": "Register a user account for local/dev story editing.",
+        "properties": {
+          "display_name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "email": {
+            "maxLength": 320,
+            "minLength": 5,
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "format": "password",
+            "maxLength": 200,
+            "minLength": 8,
+            "title": "Password",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "email",
+          "password",
+          "display_name"
+        ],
+        "title": "AuthRegisterRequest",
+        "type": "object"
+      },
+      "AuthTokenResponse": {
+        "additionalProperties": false,
+        "description": "Bearer token payload used by web and Python clients.",
+        "properties": {
+          "access_token": {
+            "title": "Access Token",
+            "type": "string"
+          },
+          "expires_at_utc": {
+            "title": "Expires At Utc",
+            "type": "string"
+          },
+          "token_type": {
+            "default": "bearer",
+            "pattern": "^bearer$",
+            "title": "Token Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token",
+          "expires_at_utc"
+        ],
+        "title": "AuthTokenResponse",
+        "type": "object"
+      },
+      "ChapterBlock": {
+        "additionalProperties": false,
+        "description": "Chapter unit that captures ordering and narrative dependencies.",
+        "properties": {
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "key": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Key",
+            "type": "string"
+          },
+          "objective": {
+            "maxLength": 3000,
+            "minLength": 1,
+            "title": "Objective",
+            "type": "string"
+          },
+          "participating_characters": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Participating Characters",
+            "type": "array"
+          },
+          "prerequisites": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Prerequisites",
+            "type": "array"
+          },
+          "required_themes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Required Themes",
+            "type": "array"
+          },
+          "title": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "title",
+          "objective"
+        ],
+        "title": "ChapterBlock",
+        "type": "object"
+      },
+      "CharacterBlock": {
+        "additionalProperties": false,
+        "description": "Character unit used in blueprint-driven story planning.",
+        "properties": {
+          "key": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Key",
+            "type": "string"
+          },
+          "motivation": {
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Motivation",
+            "type": "string"
+          },
+          "relationships": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Relationships",
+            "type": "object"
+          },
+          "role": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Role",
+            "type": "string"
+          },
+          "voice_markers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Voice Markers",
+            "type": "array"
+          }
+        },
+        "required": [
+          "key",
+          "role",
+          "motivation"
+        ],
+        "title": "CharacterBlock",
+        "type": "object"
+      },
+      "DashboardArcPointResponse": {
+        "additionalProperties": false,
+        "description": "Arc chart point payload.",
+        "properties": {
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "lane": {
+            "title": "Lane",
+            "type": "string"
+          },
+          "stage": {
+            "title": "Stage",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "lane",
+          "stage",
+          "value",
+          "label"
+        ],
+        "title": "DashboardArcPointResponse",
+        "type": "object"
+      },
+      "DashboardDrilldownResponse": {
+        "additionalProperties": false,
+        "description": "Drilldown payload for one item id.",
+        "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "evidence_segment_ids": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Evidence Segment Ids",
+            "type": "array"
+          },
+          "item_id": {
+            "title": "Item Id",
+            "type": "string"
+          },
+          "item_type": {
+            "title": "Item Type",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "item_id",
+          "item_type",
+          "title",
+          "content",
+          "evidence_segment_ids"
+        ],
+        "title": "DashboardDrilldownResponse",
+        "type": "object"
+      },
+      "DashboardGraphEdgeResponse": {
+        "additionalProperties": false,
+        "description": "Interactive graph edge payload.",
+        "properties": {
+          "relation": {
+            "title": "Relation",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "title": "Target",
+            "type": "string"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "source",
+          "target",
+          "relation",
+          "weight"
+        ],
+        "title": "DashboardGraphEdgeResponse",
+        "type": "object"
+      },
+      "DashboardGraphExportResponse": {
+        "additionalProperties": false,
+        "description": "Graph export payload.",
+        "properties": {
+          "format": {
+            "const": "svg",
+            "default": "svg",
+            "title": "Format",
+            "type": "string"
+          },
+          "svg": {
+            "title": "Svg",
+            "type": "string"
+          }
+        },
+        "required": [
+          "svg"
+        ],
+        "title": "DashboardGraphExportResponse",
+        "type": "object"
+      },
+      "DashboardGraphNodeResponse": {
+        "additionalProperties": false,
+        "description": "Interactive graph node payload.",
+        "properties": {
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "layout_x": {
+            "anyOf": [
+              {
+                "maximum": 4000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layout X"
+          },
+          "layout_y": {
+            "anyOf": [
+              {
+                "maximum": 4000.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Layout Y"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage"
+          }
+        },
+        "required": [
+          "id",
+          "label",
+          "group"
+        ],
+        "title": "DashboardGraphNodeResponse",
+        "type": "object"
+      },
+      "DashboardGraphPngExportResponse": {
+        "additionalProperties": false,
+        "description": "Graph PNG export payload.",
+        "properties": {
+          "format": {
+            "const": "png",
+            "default": "png",
+            "title": "Format",
+            "type": "string"
+          },
+          "png_base64": {
+            "title": "Png Base64",
+            "type": "string"
+          }
+        },
+        "required": [
+          "png_base64"
+        ],
+        "title": "DashboardGraphPngExportResponse",
+        "type": "object"
+      },
+      "DashboardGraphResponse": {
+        "additionalProperties": false,
+        "description": "Graph payload for interactive rendering.",
+        "properties": {
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardGraphEdgeResponse"
+            },
+            "title": "Edges",
+            "type": "array"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardGraphNodeResponse"
+            },
+            "title": "Nodes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "nodes",
+          "edges"
+        ],
+        "title": "DashboardGraphResponse",
+        "type": "object"
+      },
+      "DashboardOverviewResponse": {
+        "additionalProperties": false,
+        "description": "Big-picture dashboard card payload.",
+        "properties": {
+          "beats_count": {
+            "minimum": 0.0,
+            "title": "Beats Count",
+            "type": "integer"
+          },
+          "confidence_floor": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence Floor",
+            "type": "number"
+          },
+          "events_count": {
+            "minimum": 0.0,
+            "title": "Events Count",
+            "type": "integer"
+          },
+          "macro_thesis": {
+            "title": "Macro Thesis",
+            "type": "string"
+          },
+          "quality_passed": {
+            "title": "Quality Passed",
+            "type": "boolean"
+          },
+          "themes_count": {
+            "minimum": 0.0,
+            "title": "Themes Count",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "macro_thesis",
+          "confidence_floor",
+          "quality_passed",
+          "events_count",
+          "beats_count",
+          "themes_count"
+        ],
+        "title": "DashboardOverviewResponse",
+        "type": "object"
+      },
+      "DashboardPngExportResponse": {
+        "additionalProperties": false,
+        "description": "PNG export payload.",
+        "properties": {
+          "format": {
+            "const": "png",
+            "default": "png",
+            "title": "Format",
+            "type": "string"
+          },
+          "png_base64": {
+            "title": "Png Base64",
+            "type": "string"
+          }
+        },
+        "required": [
+          "png_base64"
+        ],
+        "title": "DashboardPngExportResponse",
+        "type": "object"
+      },
+      "DashboardSvgExportResponse": {
+        "additionalProperties": false,
+        "description": "SVG export payload.",
+        "properties": {
+          "format": {
+            "const": "svg",
+            "default": "svg",
+            "title": "Format",
+            "type": "string"
+          },
+          "svg": {
+            "title": "Svg",
+            "type": "string"
+          }
+        },
+        "required": [
+          "svg"
+        ],
+        "title": "DashboardSvgExportResponse",
+        "type": "object"
+      },
+      "DashboardThemeHeatmapCellResponse": {
+        "additionalProperties": false,
+        "description": "Theme heatmap cell payload.",
+        "properties": {
+          "intensity": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Intensity",
+            "type": "number"
+          },
+          "stage": {
+            "title": "Stage",
+            "type": "string"
+          },
+          "theme": {
+            "title": "Theme",
+            "type": "string"
+          }
+        },
+        "required": [
+          "theme",
+          "stage",
+          "intensity"
+        ],
+        "title": "DashboardThemeHeatmapCellResponse",
+        "type": "object"
+      },
+      "DashboardTimelineLaneResponse": {
+        "additionalProperties": false,
+        "description": "Timeline lane payload used by visualization UIs.",
+        "properties": {
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "lane": {
+            "title": "Lane",
+            "type": "string"
+          }
+        },
+        "required": [
+          "lane",
+          "items"
+        ],
+        "title": "DashboardTimelineLaneResponse",
+        "type": "object"
+      },
+      "EssayBlueprint-Input": {
+        "additionalProperties": false,
+        "description": "Portable essay-mode contract for deterministic quality checks.",
+        "properties": {
+          "policy": {
+            "$ref": "#/components/schemas/EssayPolicy"
+          },
+          "prompt": {
+            "maxLength": 8000,
+            "minLength": 1,
+            "title": "Prompt",
+            "type": "string"
+          },
+          "rubric": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Rubric",
+            "type": "array"
+          }
+        },
+        "required": [
+          "prompt",
+          "policy"
+        ],
+        "title": "EssayBlueprint",
+        "type": "object"
+      },
+      "EssayBlueprint-Output": {
+        "additionalProperties": false,
+        "description": "Portable essay-mode contract for deterministic quality checks.",
+        "properties": {
+          "policy": {
+            "$ref": "#/components/schemas/EssayPolicy"
+          },
+          "prompt": {
+            "maxLength": 8000,
+            "minLength": 1,
+            "title": "Prompt",
+            "type": "string"
+          },
+          "rubric": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Rubric",
+            "type": "array"
+          }
+        },
+        "required": [
+          "prompt",
+          "policy"
+        ],
+        "title": "EssayBlueprint",
+        "type": "object"
+      },
+      "EssayCreateRequest": {
+        "additionalProperties": false,
+        "description": "Create one essay workspace for the authenticated user.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/EssayBlueprint-Input"
+          },
+          "draft_text": {
+            "default": "",
+            "maxLength": 120000,
+            "title": "Draft Text",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "blueprint"
+        ],
+        "title": "EssayCreateRequest",
+        "type": "object"
+      },
+      "EssayEvaluateRequest": {
+        "additionalProperties": false,
+        "description": "Evaluate persisted essay with optional override draft text.",
+        "properties": {
+          "draft_text": {
+            "anyOf": [
+              {
+                "maxLength": 120000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          }
+        },
+        "title": "EssayEvaluateRequest",
+        "type": "object"
+      },
+      "EssayEvaluationResponse": {
+        "additionalProperties": false,
+        "description": "Evaluation output for one essay draft.",
+        "properties": {
+          "checks": {
+            "items": {
+              "$ref": "#/components/schemas/EssayQualityCheckResponse"
+            },
+            "title": "Checks",
+            "type": "array"
+          },
+          "citation_count": {
+            "minimum": 0.0,
+            "title": "Citation Count",
+            "type": "integer"
+          },
+          "essay_id": {
+            "title": "Essay Id",
+            "type": "string"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "passed": {
+            "title": "Passed",
+            "type": "boolean"
+          },
+          "required_citations": {
+            "minimum": 0.0,
+            "title": "Required Citations",
+            "type": "integer"
+          },
+          "score": {
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Score",
+            "type": "number"
+          },
+          "word_count": {
+            "minimum": 0.0,
+            "title": "Word Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "essay_id",
+          "owner_id",
+          "passed",
+          "score",
+          "word_count",
+          "citation_count",
+          "required_citations",
+          "checks"
+        ],
+        "title": "EssayEvaluationResponse",
+        "type": "object"
+      },
+      "EssayPolicy": {
+        "additionalProperties": false,
+        "description": "Quality policy enforcing draft shape for essay mode.",
+        "properties": {
+          "audience": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Audience",
+            "type": "string"
+          },
+          "banned_phrases": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Banned Phrases",
+            "type": "array"
+          },
+          "max_words": {
+            "default": 1200,
+            "maximum": 20000.0,
+            "minimum": 150.0,
+            "title": "Max Words",
+            "type": "integer"
+          },
+          "min_words": {
+            "default": 600,
+            "maximum": 10000.0,
+            "minimum": 100.0,
+            "title": "Min Words",
+            "type": "integer"
+          },
+          "required_citations": {
+            "default": 0,
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Required Citations",
+            "type": "integer"
+          },
+          "required_sections": {
+            "items": {
+              "$ref": "#/components/schemas/EssaySectionRequirement"
+            },
+            "title": "Required Sections",
+            "type": "array"
+          },
+          "thesis_statement": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Thesis Statement",
+            "type": "string"
+          },
+          "tone": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Tone",
+            "type": "string"
+          }
+        },
+        "required": [
+          "thesis_statement",
+          "audience",
+          "tone"
+        ],
+        "title": "EssayPolicy",
+        "type": "object"
+      },
+      "EssayQualityCheckResponse": {
+        "additionalProperties": false,
+        "description": "One quality finding from essay evaluation.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "error",
+              "warning"
+            ],
+            "title": "Severity",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "severity",
+          "message"
+        ],
+        "title": "EssayQualityCheckResponse",
+        "type": "object"
+      },
+      "EssayResponse": {
+        "additionalProperties": false,
+        "description": "Essay payload returned by API.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/EssayBlueprint-Output"
+          },
+          "created_at_utc": {
+            "title": "Created At Utc",
+            "type": "string"
+          },
+          "draft_text": {
+            "title": "Draft Text",
+            "type": "string"
+          },
+          "essay_id": {
+            "title": "Essay Id",
+            "type": "string"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at_utc": {
+            "title": "Updated At Utc",
+            "type": "string"
+          }
+        },
+        "required": [
+          "essay_id",
+          "owner_id",
+          "title",
+          "blueprint",
+          "draft_text",
+          "created_at_utc",
+          "updated_at_utc"
+        ],
+        "title": "EssayResponse",
+        "type": "object"
+      },
+      "EssaySectionRequirement": {
+        "additionalProperties": false,
+        "description": "Expected section contract for a structured essay.",
+        "properties": {
+          "key": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Key",
+            "type": "string"
+          },
+          "min_paragraphs": {
+            "default": 1,
+            "maximum": 10.0,
+            "minimum": 1.0,
+            "title": "Min Paragraphs",
+            "type": "integer"
+          },
+          "purpose": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Purpose",
+            "type": "string"
+          },
+          "required_terms": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Required Terms",
+            "type": "array"
+          }
+        },
+        "required": [
+          "key",
+          "purpose"
+        ],
+        "title": "EssaySectionRequirement",
+        "type": "object"
+      },
+      "EssayUpdateRequest": {
+        "additionalProperties": false,
+        "description": "Update one essay workspace.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/EssayBlueprint-Input"
+          },
+          "draft_text": {
+            "default": "",
+            "maxLength": 120000,
+            "title": "Draft Text",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "blueprint"
+        ],
+        "title": "EssayUpdateRequest",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HealthResponse": {
+        "description": "Simple health payload used by probes.",
+        "properties": {
+          "service": {
+            "default": "story_gen",
+            "title": "Service",
+            "type": "string"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "title": "HealthResponse",
+        "type": "object"
+      },
+      "IngestionStatusResponse": {
+        "additionalProperties": false,
+        "description": "Ingestion job status payload for dashboard polling.",
+        "properties": {
+          "attempt_count": {
+            "minimum": 1.0,
+            "title": "Attempt Count",
+            "type": "integer"
+          },
+          "completed_at_utc": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At Utc"
+          },
+          "created_at_utc": {
+            "title": "Created At Utc",
+            "type": "string"
+          },
+          "dedupe_key": {
+            "title": "Dedupe Key",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "title": "Idempotency Key",
+            "type": "string"
+          },
+          "issue_count": {
+            "minimum": 0.0,
+            "title": "Issue Count",
+            "type": "integer"
+          },
+          "job_id": {
+            "title": "Job Id",
+            "type": "string"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "retry_count": {
+            "minimum": 0.0,
+            "title": "Retry Count",
+            "type": "integer"
+          },
+          "run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Id"
+          },
+          "segment_count": {
+            "minimum": 0.0,
+            "title": "Segment Count",
+            "type": "integer"
+          },
+          "source_hash": {
+            "title": "Source Hash",
+            "type": "string"
+          },
+          "source_type": {
+            "title": "Source Type",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "processing",
+              "succeeded",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "story_id": {
+            "title": "Story Id",
+            "type": "string"
+          },
+          "updated_at_utc": {
+            "title": "Updated At Utc",
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id",
+          "story_id",
+          "owner_id",
+          "source_type",
+          "idempotency_key",
+          "source_hash",
+          "dedupe_key",
+          "status",
+          "attempt_count",
+          "retry_count",
+          "segment_count",
+          "issue_count",
+          "created_at_utc",
+          "updated_at_utc"
+        ],
+        "title": "IngestionStatusResponse",
+        "type": "object"
+      },
+      "StoryAnalysisGateResponse": {
+        "additionalProperties": false,
+        "description": "Quality gate summary for analysis runs.",
+        "properties": {
+          "confidence_floor": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Confidence Floor",
+            "type": "number"
+          },
+          "hallucination_risk": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Hallucination Risk",
+            "type": "number"
+          },
+          "passed": {
+            "title": "Passed",
+            "type": "boolean"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reasons",
+            "type": "array"
+          },
+          "translation_quality": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Translation Quality",
+            "type": "number"
+          }
+        },
+        "required": [
+          "passed",
+          "confidence_floor",
+          "hallucination_risk",
+          "translation_quality"
+        ],
+        "title": "StoryAnalysisGateResponse",
+        "type": "object"
+      },
+      "StoryAnalysisRunRequest": {
+        "additionalProperties": false,
+        "description": "Trigger a full story intelligence analysis run.",
+        "properties": {
+          "idempotency_key": {
+            "anyOf": [
+              {
+                "maxLength": 140,
+                "minLength": 3,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Idempotency Key"
+          },
+          "source_text": {
+            "anyOf": [
+              {
+                "maxLength": 200000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "source_type": {
+            "default": "text",
+            "enum": [
+              "text",
+              "document",
+              "transcript"
+            ],
+            "title": "Source Type",
+            "type": "string"
+          },
+          "target_language": {
+            "default": "en",
+            "maxLength": 16,
+            "minLength": 2,
+            "title": "Target Language",
+            "type": "string"
+          }
+        },
+        "title": "StoryAnalysisRunRequest",
+        "type": "object"
+      },
+      "StoryAnalysisRunResponse": {
+        "additionalProperties": false,
+        "description": "Summary view of one story analysis run.",
+        "properties": {
+          "analyzed_at_utc": {
+            "title": "Analyzed At Utc",
+            "type": "string"
+          },
+          "beat_count": {
+            "minimum": 1.0,
+            "title": "Beat Count",
+            "type": "integer"
+          },
+          "event_count": {
+            "minimum": 1.0,
+            "title": "Event Count",
+            "type": "integer"
+          },
+          "insight_count": {
+            "minimum": 1.0,
+            "title": "Insight Count",
+            "type": "integer"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "quality_gate": {
+            "$ref": "#/components/schemas/StoryAnalysisGateResponse"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "segment_count": {
+            "minimum": 1.0,
+            "title": "Segment Count",
+            "type": "integer"
+          },
+          "source_language": {
+            "title": "Source Language",
+            "type": "string"
+          },
+          "story_id": {
+            "title": "Story Id",
+            "type": "string"
+          },
+          "target_language": {
+            "title": "Target Language",
+            "type": "string"
+          },
+          "theme_count": {
+            "minimum": 0.0,
+            "title": "Theme Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "story_id",
+          "owner_id",
+          "schema_version",
+          "analyzed_at_utc",
+          "source_language",
+          "target_language",
+          "segment_count",
+          "event_count",
+          "beat_count",
+          "theme_count",
+          "insight_count",
+          "quality_gate"
+        ],
+        "title": "StoryAnalysisRunResponse",
+        "type": "object"
+      },
+      "StoryBlueprint": {
+        "additionalProperties": false,
+        "description": "Portable story contract users can edit via web or Python.",
+        "properties": {
+          "canon_rules": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Canon Rules",
+            "type": "array"
+          },
+          "chapters": {
+            "items": {
+              "$ref": "#/components/schemas/ChapterBlock"
+            },
+            "title": "Chapters",
+            "type": "array"
+          },
+          "characters": {
+            "items": {
+              "$ref": "#/components/schemas/CharacterBlock"
+            },
+            "title": "Characters",
+            "type": "array"
+          },
+          "premise": {
+            "maxLength": 4000,
+            "minLength": 1,
+            "title": "Premise",
+            "type": "string"
+          },
+          "themes": {
+            "items": {
+              "$ref": "#/components/schemas/ThemeBlock"
+            },
+            "title": "Themes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "premise"
+        ],
+        "title": "StoryBlueprint",
+        "type": "object"
+      },
+      "StoryCreateRequest": {
+        "additionalProperties": false,
+        "description": "Create one story workspace for the authenticated user.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/StoryBlueprint"
+          },
+          "title": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "blueprint"
+        ],
+        "title": "StoryCreateRequest",
+        "type": "object"
+      },
+      "StoryFeatureRowResponse": {
+        "additionalProperties": false,
+        "description": "Feature metrics extracted for one chapter.",
+        "properties": {
+          "avg_sentence_length": {
+            "title": "Avg Sentence Length",
+            "type": "number"
+          },
+          "chapter_index": {
+            "title": "Chapter Index",
+            "type": "integer"
+          },
+          "chapter_key": {
+            "title": "Chapter Key",
+            "type": "string"
+          },
+          "dialogue_line_ratio": {
+            "title": "Dialogue Line Ratio",
+            "type": "number"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "sentence_count": {
+            "title": "Sentence Count",
+            "type": "integer"
+          },
+          "source_length_chars": {
+            "title": "Source Length Chars",
+            "type": "integer"
+          },
+          "story_id": {
+            "title": "Story Id",
+            "type": "string"
+          },
+          "token_count": {
+            "title": "Token Count",
+            "type": "integer"
+          },
+          "top_keywords": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Top Keywords",
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "story_id",
+          "chapter_key",
+          "chapter_index",
+          "source_length_chars",
+          "sentence_count",
+          "token_count",
+          "avg_sentence_length",
+          "dialogue_line_ratio",
+          "top_keywords"
+        ],
+        "title": "StoryFeatureRowResponse",
+        "type": "object"
+      },
+      "StoryFeatureRunResponse": {
+        "additionalProperties": false,
+        "description": "Latest persisted feature extraction result for one story.",
+        "properties": {
+          "chapter_features": {
+            "items": {
+              "$ref": "#/components/schemas/StoryFeatureRowResponse"
+            },
+            "title": "Chapter Features",
+            "type": "array"
+          },
+          "extracted_at_utc": {
+            "title": "Extracted At Utc",
+            "type": "string"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "schema_version": {
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "story_id": {
+            "title": "Story Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "run_id",
+          "story_id",
+          "owner_id",
+          "schema_version",
+          "extracted_at_utc",
+          "chapter_features"
+        ],
+        "title": "StoryFeatureRunResponse",
+        "type": "object"
+      },
+      "StoryResponse": {
+        "additionalProperties": false,
+        "description": "Story payload returned by the API.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/StoryBlueprint"
+          },
+          "created_at_utc": {
+            "title": "Created At Utc",
+            "type": "string"
+          },
+          "owner_id": {
+            "title": "Owner Id",
+            "type": "string"
+          },
+          "story_id": {
+            "title": "Story Id",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at_utc": {
+            "title": "Updated At Utc",
+            "type": "string"
+          }
+        },
+        "required": [
+          "story_id",
+          "owner_id",
+          "title",
+          "blueprint",
+          "created_at_utc",
+          "updated_at_utc"
+        ],
+        "title": "StoryResponse",
+        "type": "object"
+      },
+      "StoryUpdateRequest": {
+        "additionalProperties": false,
+        "description": "Update title and blueprint for an existing story workspace.",
+        "properties": {
+          "blueprint": {
+            "$ref": "#/components/schemas/StoryBlueprint"
+          },
+          "title": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title",
+          "blueprint"
+        ],
+        "title": "StoryUpdateRequest",
+        "type": "object"
+      },
+      "ThemeBlock": {
+        "additionalProperties": false,
+        "description": "Theme unit used in blueprint-driven story planning.",
+        "properties": {
+          "key": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Key",
+            "type": "string"
+          },
+          "priority": {
+            "default": 1,
+            "maximum": 10.0,
+            "minimum": 1.0,
+            "title": "Priority",
+            "type": "integer"
+          },
+          "statement": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Statement",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "statement"
+        ],
+        "title": "ThemeBlock",
+        "type": "object"
+      },
+      "UserResponse": {
+        "additionalProperties": false,
+        "description": "Public user profile returned from authenticated endpoints.",
+        "properties": {
+          "created_at_utc": {
+            "title": "Created At Utc",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "email",
+          "display_name",
+          "created_at_utc"
+        ],
+        "title": "UserResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "scheme": "bearer",
+        "type": "http"
+      }
+    }
+  },
+  "info": {
+    "description": "Story intelligence API for auth, story workspaces, analysis runs, and dashboard read models.\n\nUse `/docs` for interactive Swagger UI while the service is running. A static OpenAPI snapshot is published with repository docs for hosted browsing.",
+    "summary": "Local/dev HTTP API for story_gen",
+    "title": "story_gen API",
+    "version": "0.3.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1": {
+      "get": {
+        "description": "List API runtime mode and available endpoint surfaces.",
+        "operationId": "api_v1_root_api_v1_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiRootResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api V1 Root",
+        "tags": [
+          "api"
+        ]
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "description": "Authenticate credentials and issue a time-limited bearer token.",
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthLoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "description": "Create a local user account for bearer-token authentication.",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Register",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/essays": {
+      "get": {
+        "description": "List owner-scoped essay workspaces with a bounded limit.",
+        "operationId": "list_essays_api_v1_essays_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EssayResponse"
+                  },
+                  "title": "Response List Essays Api V1 Essays Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Essays",
+        "tags": [
+          "essays"
+        ]
+      },
+      "post": {
+        "description": "Create one owner-scoped essay workspace and optional draft text.",
+        "operationId": "create_essay_api_v1_essays_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EssayCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EssayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Essay",
+        "tags": [
+          "essays"
+        ]
+      }
+    },
+    "/api/v1/essays/{essay_id}": {
+      "get": {
+        "description": "Read one owner-scoped essay workspace by identifier.",
+        "operationId": "get_essay_api_v1_essays__essay_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "essay_id",
+            "required": true,
+            "schema": {
+              "title": "Essay Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EssayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Essay",
+        "tags": [
+          "essays"
+        ]
+      },
+      "put": {
+        "description": "Update title, policy blueprint, and draft for one essay workspace.",
+        "operationId": "update_essay_api_v1_essays__essay_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "essay_id",
+            "required": true,
+            "schema": {
+              "title": "Essay Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EssayUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EssayResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Essay",
+        "tags": [
+          "essays"
+        ]
+      }
+    },
+    "/api/v1/essays/{essay_id}/evaluate": {
+      "post": {
+        "description": "Run deterministic essay quality checks and return scored findings.",
+        "operationId": "evaluate_essay_api_v1_essays__essay_id__evaluate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "essay_id",
+            "required": true,
+            "schema": {
+              "title": "Essay Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EssayEvaluateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EssayEvaluationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Evaluate Essay",
+        "tags": [
+          "essays"
+        ]
+      }
+    },
+    "/api/v1/me": {
+      "get": {
+        "description": "Return the authenticated user's profile.",
+        "operationId": "me_api_v1_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Me",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/stories": {
+      "get": {
+        "description": "List owner-scoped story workspaces with a bounded limit.",
+        "operationId": "list_stories_api_v1_stories_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StoryResponse"
+                  },
+                  "title": "Response List Stories Api V1 Stories Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Stories",
+        "tags": [
+          "stories"
+        ]
+      },
+      "post": {
+        "description": "Create one owner-scoped story workspace from a validated blueprint.",
+        "operationId": "create_story_api_v1_stories_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StoryCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Story",
+        "tags": [
+          "stories"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}": {
+      "get": {
+        "description": "Read one owner-scoped story workspace by identifier.",
+        "operationId": "get_story_api_v1_stories__story_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Story",
+        "tags": [
+          "stories"
+        ]
+      },
+      "put": {
+        "description": "Update title and blueprint for one owner-scoped story.",
+        "operationId": "update_story_api_v1_stories__story_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StoryUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Story",
+        "tags": [
+          "stories"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/analysis/latest": {
+      "get": {
+        "description": "Fetch the latest persisted analysis run summary for a story.",
+        "operationId": "get_latest_analysis_api_v1_stories__story_id__analysis_latest_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryAnalysisRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Latest Analysis",
+        "tags": [
+          "stories",
+          "analysis"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/analysis/run": {
+      "post": {
+        "description": "Run ingestion + analysis pipeline and persist a new analysis artifact.",
+        "operationId": "run_analysis_api_v1_stories__story_id__analysis_run_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StoryAnalysisRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryAnalysisRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Run Analysis",
+        "tags": [
+          "stories",
+          "analysis"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/arcs": {
+      "get": {
+        "description": "Return arc points for character, conflict, and emotion trajectories.",
+        "operationId": "dashboard_arcs_api_v1_stories__story_id__dashboard_arcs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardArcPointResponse"
+                  },
+                  "title": "Response Dashboard Arcs Api V1 Stories  Story Id  Dashboard Arcs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Arcs",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/drilldown/{item_id}": {
+      "get": {
+        "description": "Return detail content and evidence references for one dashboard item.",
+        "operationId": "dashboard_drilldown_api_v1_stories__story_id__dashboard_drilldown__item_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardDrilldownResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Drilldown",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/graph": {
+      "get": {
+        "description": "Return graph nodes and edges for interactive dashboard rendering.",
+        "operationId": "dashboard_graph_api_v1_stories__story_id__dashboard_graph_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardGraphResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Graph",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/graph/export.png": {
+      "get": {
+        "description": "Return deterministic PNG export of latest dashboard graph.",
+        "operationId": "dashboard_graph_export_png_api_v1_stories__story_id__dashboard_graph_export_png_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardGraphPngExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Graph Export Png",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/graph/export.svg": {
+      "get": {
+        "description": "Return deterministic SVG export of latest dashboard graph.",
+        "operationId": "dashboard_graph_export_svg_api_v1_stories__story_id__dashboard_graph_export_svg_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardGraphExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Graph Export Svg",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/overview": {
+      "get": {
+        "description": "Return high-level dashboard cards for the latest story analysis.",
+        "operationId": "dashboard_overview_api_v1_stories__story_id__dashboard_overview_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardOverviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Overview",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/themes/heatmap": {
+      "get": {
+        "description": "Return theme-by-stage heatmap cells for the latest analysis.",
+        "operationId": "dashboard_theme_heatmap_api_v1_stories__story_id__dashboard_themes_heatmap_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardThemeHeatmapCellResponse"
+                  },
+                  "title": "Response Dashboard Theme Heatmap Api V1 Stories  Story Id  Dashboard Themes Heatmap Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Theme Heatmap",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/themes/heatmap/export.png": {
+      "get": {
+        "description": "Render latest theme heatmap as deterministic PNG payload.",
+        "operationId": "dashboard_theme_heatmap_export_png_api_v1_stories__story_id__dashboard_themes_heatmap_export_png_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardPngExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Theme Heatmap Export Png",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/themes/heatmap/export.svg": {
+      "get": {
+        "description": "Render latest theme heatmap as deterministic SVG payload.",
+        "operationId": "dashboard_theme_heatmap_export_svg_api_v1_stories__story_id__dashboard_themes_heatmap_export_svg_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSvgExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Theme Heatmap Export Svg",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/timeline": {
+      "get": {
+        "description": "Return timeline lanes in narrative and chronological views.",
+        "operationId": "dashboard_timeline_api_v1_stories__story_id__dashboard_timeline_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardTimelineLaneResponse"
+                  },
+                  "title": "Response Dashboard Timeline Api V1 Stories  Story Id  Dashboard Timeline Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Timeline",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/timeline/export.png": {
+      "get": {
+        "description": "Render latest timeline lanes as deterministic PNG payload.",
+        "operationId": "dashboard_timeline_export_png_api_v1_stories__story_id__dashboard_timeline_export_png_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardPngExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Timeline Export Png",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/timeline/export.svg": {
+      "get": {
+        "description": "Render latest timeline lanes as deterministic SVG payload.",
+        "operationId": "dashboard_timeline_export_svg_api_v1_stories__story_id__dashboard_timeline_export_svg_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSvgExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Timeline Export Svg",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/v1/overview": {
+      "get": {
+        "description": "Return high-level dashboard cards for the latest story analysis.",
+        "operationId": "dashboard_overview_api_v1_stories__story_id__dashboard_v1_overview_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardOverviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Overview",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/v1/themes/heatmap": {
+      "get": {
+        "description": "Return theme-by-stage heatmap cells for the latest analysis.",
+        "operationId": "dashboard_theme_heatmap_api_v1_stories__story_id__dashboard_v1_themes_heatmap_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardThemeHeatmapCellResponse"
+                  },
+                  "title": "Response Dashboard Theme Heatmap Api V1 Stories  Story Id  Dashboard V1 Themes Heatmap Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Theme Heatmap",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/dashboard/v1/timeline": {
+      "get": {
+        "description": "Return timeline lanes in narrative and chronological views.",
+        "operationId": "dashboard_timeline_api_v1_stories__story_id__dashboard_v1_timeline_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardTimelineLaneResponse"
+                  },
+                  "title": "Response Dashboard Timeline Api V1 Stories  Story Id  Dashboard V1 Timeline Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Dashboard Timeline",
+        "tags": [
+          "stories",
+          "dashboard"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/features/extract": {
+      "post": {
+        "description": "Run deterministic feature extraction over story chapter content.",
+        "operationId": "extract_features_api_v1_stories__story_id__features_extract_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryFeatureRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Extract Features",
+        "tags": [
+          "stories",
+          "features"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/features/latest": {
+      "get": {
+        "description": "Fetch the latest persisted feature extraction result for a story.",
+        "operationId": "get_latest_features_api_v1_stories__story_id__features_latest_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StoryFeatureRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Latest Features",
+        "tags": [
+          "stories",
+          "features"
+        ]
+      }
+    },
+    "/api/v1/stories/{story_id}/ingestion/status": {
+      "get": {
+        "description": "Return latest ingestion job status for an owner-scoped story.",
+        "operationId": "ingestion_status_api_v1_stories__story_id__ingestion_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "story_id",
+            "required": true,
+            "schema": {
+              "title": "Story Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestionStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Ingestion Status",
+        "tags": [
+          "stories",
+          "analysis"
+        ]
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Return service liveness metadata for probes.",
+        "operationId": "healthz_healthz_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Healthz",
+        "tags": [
+          "system"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "description": "Service health and runtime metadata.",
+      "name": "system"
+    },
+    {
+      "description": "API discovery and root-level capability listing.",
+      "name": "api"
+    },
+    {
+      "description": "Registration, login, and profile lookups.",
+      "name": "auth"
+    },
+    {
+      "description": "Story workspace CRUD and ownership-scoped reads.",
+      "name": "stories"
+    },
+    {
+      "description": "Story feature extraction workflows.",
+      "name": "features"
+    },
+    {
+      "description": "Story intelligence extraction, translation, and scoring workflows.",
+      "name": "analysis"
+    },
+    {
+      "description": "Visualization-oriented dashboard read models.",
+      "name": "dashboard"
+    },
+    {
+      "description": "Essay workspace CRUD and deterministic quality checks.",
+      "name": "essays"
+    }
+  ]
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,11 +70,12 @@ S3-compatible note:
 
 1. Keep Pages focused on the product demo at repo root.
 2. Publish static docs snapshot on Pages under `/docs`.
-3. Publish static Python API reference on Pages under `/pydoc`.
-4. Keep docs mirrored into the repository wiki for collaborative edits.
-5. Keep API local-first for editing and workflow testing.
-6. Keep web studio and Python interface on one shared blueprint contract.
-7. Add CORS + stronger auth + storage migration when remote multi-user hosting is needed.
+3. Publish static OpenAPI snapshot under `/docs/assets/openapi/`.
+4. Publish static Python API reference on Pages under `/pydoc`.
+5. Keep docs mirrored into the repository wiki for collaborative edits.
+6. Keep API local-first for editing and workflow testing.
+7. Keep web studio and Python interface on one shared blueprint contract.
+8. Add CORS + stronger auth + storage migration when remote multi-user hosting is needed.
 
 ## Wiki synchronization
 

--- a/docs/github_collaboration.md
+++ b/docs/github_collaboration.md
@@ -42,6 +42,7 @@ Automation:
   when docs or sync tooling changes.
 - You can also run the same sync workflow manually from the Actions tab.
 - `.github/workflows/deploy-pages.yml` builds MkDocs and publishes it under `/docs/` after successful CI on `develop`/`main`.
+  The same workflow also exports a static OpenAPI snapshot consumed by `docs/api.md`.
 
 ```bash
 make wiki-sync       # update local wiki clone from docs/

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@
 - Dependency model: `docs/dependency_charts.md`
 - Reference ingestion: `docs/reference_pipeline.md`
 - Native acceleration: `docs/native_cpp.md`
-- API stub: `docs/api.md`
+- API reference: `docs/api.md`
 - Python API reference: `docs/python_api_reference.md`
 - Developer setup runbook: `docs/developer_setup.md`
 - Wiki sync guide: `docs/wiki_docs.md`

--- a/docs/python_api_reference.md
+++ b/docs/python_api_reference.md
@@ -7,6 +7,16 @@
 
 The hosted Python reference is generated with `pdoc` during Pages deploy and is static.
 
+Primary modules surfaced in pydoc include:
+
+- `story_gen.api.contracts` (validated request/response and blueprint models)
+- `story_gen.api.python_interface` (typed Python client for API workflows)
+- `story_gen.core.*` analysis, extraction, quality, and dashboard logic
+- `story_gen.adapters.*` persistence and IO adapters
+
+To keep pydoc useful, public classes/functions should include concise docstrings and
+explicit type hints.
+
 ## Local generation
 
 From repository root:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - 0027 Pipeline Ingestion Resilience and Canary Enforcement: adr/0027-pipeline-ingestion-resilience-and-canary.md
       - 0028 QA Evaluation Harness and Calibration Gates: adr/0028-qa-evaluation-harness-and-calibration-gates.md
       - 0029 NLP Provider Resilience and Insight Calibration: adr/0029-nlp-provider-resilience-and-insight-calibration.md
+      - 0030 OpenAPI Snapshot and Hosted API Reference: adr/0030-openapi-snapshot-and-hosted-api-reference.md
   - Guides:
       - Dependency Charts: dependency_charts.md
       - Reference Pipeline: reference_pipeline.md

--- a/src/story_gen/api/python_interface.py
+++ b/src/story_gen/api/python_interface.py
@@ -37,13 +37,16 @@ class StoryApiClient:
     """Tiny typed API client for Python users."""
 
     def __init__(self, api_base_url: str = "http://127.0.0.1:8000") -> None:
+        """Initialize client with an API base URL."""
         self._api_base_url = api_base_url.rstrip("/")
 
     @property
     def api_base_url(self) -> str:
+        """Return normalized API base URL."""
         return self._api_base_url
 
     def register(self, *, email: str, password: str, display_name: str) -> None:
+        """Create an account for local/dev bearer-token authentication."""
         response = httpx.post(
             f"{self._api_base_url}/api/v1/auth/register",
             json={
@@ -56,6 +59,7 @@ class StoryApiClient:
         response.raise_for_status()
 
     def login(self, *, email: str, password: str) -> AuthSession:
+        """Authenticate and return a reusable auth session."""
         response = httpx.post(
             f"{self._api_base_url}/api/v1/auth/login",
             json={"email": email, "password": password},
@@ -73,6 +77,7 @@ class StoryApiClient:
         title: str,
         blueprint: StoryBlueprint,
     ) -> StoryResponse:
+        """Create a story workspace from a validated blueprint."""
         request = StoryCreateRequest(title=title, blueprint=blueprint)
         response = httpx.post(
             f"{session.api_base_url}/api/v1/stories",
@@ -91,6 +96,7 @@ class StoryApiClient:
         title: str,
         blueprint: StoryBlueprint,
     ) -> StoryResponse:
+        """Update title and blueprint for an existing story workspace."""
         request = StoryUpdateRequest(title=title, blueprint=blueprint)
         response = httpx.put(
             f"{session.api_base_url}/api/v1/stories/{story_id}",
@@ -102,6 +108,7 @@ class StoryApiClient:
         return StoryResponse.model_validate(response.json())
 
     def extract_features(self, *, session: AuthSession, story_id: str) -> StoryFeatureRunResponse:
+        """Trigger chapter-level feature extraction for one story."""
         response = httpx.post(
             f"{session.api_base_url}/api/v1/stories/{story_id}/features/extract",
             headers={"Authorization": f"Bearer {session.access_token}"},
@@ -118,6 +125,7 @@ class StoryApiClient:
         blueprint: EssayBlueprint,
         draft_text: str = "",
     ) -> EssayResponse:
+        """Create an essay workspace with optional draft text."""
         request = EssayCreateRequest(title=title, blueprint=blueprint, draft_text=draft_text)
         response = httpx.post(
             f"{session.api_base_url}/api/v1/essays",
@@ -137,6 +145,7 @@ class StoryApiClient:
         blueprint: EssayBlueprint,
         draft_text: str,
     ) -> EssayResponse:
+        """Update essay title, blueprint policy, and draft text."""
         request = EssayUpdateRequest(title=title, blueprint=blueprint, draft_text=draft_text)
         response = httpx.put(
             f"{session.api_base_url}/api/v1/essays/{essay_id}",
@@ -154,6 +163,7 @@ class StoryApiClient:
         essay_id: str,
         draft_text: str | None = None,
     ) -> EssayEvaluationResponse:
+        """Run deterministic essay quality checks."""
         request = EssayEvaluateRequest(draft_text=draft_text)
         response = httpx.post(
             f"{session.api_base_url}/api/v1/essays/{essay_id}/evaluate",
@@ -165,6 +175,7 @@ class StoryApiClient:
         return EssayEvaluationResponse.model_validate(response.json())
 
     def latest_features(self, *, session: AuthSession, story_id: str) -> StoryFeatureRunResponse:
+        """Fetch the most recent persisted feature extraction result."""
         response = httpx.get(
             f"{session.api_base_url}/api/v1/stories/{story_id}/features/latest",
             headers={"Authorization": f"Bearer {session.access_token}"},

--- a/src/story_gen/pre_push_checks.py
+++ b/src/story_gen/pre_push_checks.py
@@ -32,6 +32,15 @@ def main() -> None:
     run([uv_executable, "lock", "--check"])
     run([sys.executable, str(REPO_ROOT / "tools" / "check_imports.py")])
     run([sys.executable, str(REPO_ROOT / "tools" / "check_contract_drift.py")])
+    run(
+        [
+            uv_executable,
+            "run",
+            "python",
+            "tools/export_openapi_snapshot.py",
+            "--check",
+        ]
+    )
     run_tool("ruff", "check", ".")
     run_tool("ruff", "format", "--check", ".")
     run_tool("mypy")

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -106,6 +107,13 @@ def test_swagger_redoc_and_openapi_endpoints_are_available() -> None:
     payload = openapi.json()
     assert payload["info"]["title"] == "story_gen API"
     assert any(tag["name"] == "auth" for tag in payload["tags"])
+
+
+def test_openapi_snapshot_matches_generated_schema() -> None:
+    snapshot_path = Path("docs/assets/openapi/story_gen.openapi.json")
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    generated = create_app().openapi()
+    assert snapshot == generated
 
 
 def test_api_root_reports_auth_and_story_endpoints() -> None:

--- a/tests/test_pre_push_checks.py
+++ b/tests/test_pre_push_checks.py
@@ -38,18 +38,20 @@ def test_pre_push_checks_runs_expected_commands_in_order(
     assert executed[2][-1].endswith("check_imports.py")
     assert executed[3][0] == sys.executable
     assert executed[3][-1].endswith("check_contract_drift.py")
-    assert executed[4][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "ruff"]
-    assert executed[4][-2:] == ["check", "."]
+    assert executed[4][:3] == ["uv", "run", "python"]
+    assert executed[4][-2:] == ["tools/export_openapi_snapshot.py", "--check"]
     assert executed[5][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "ruff"]
-    assert executed[5][-3:] == ["format", "--check", "."]
-    assert executed[6][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "mypy"]
-    assert executed[7][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "pytest"]
-    assert executed[8][:3] == ["uv", "run", "story-pipeline-canary"]
-    assert executed[8][-1] == "--strict"
-    assert executed[9][:3] == ["uv", "run", "story-qa-eval"]
-    assert executed[9][-2:] == ["--output", "work/qa/evaluation_summary.json"]
-    assert executed[10][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "mkdocs"]
-    assert executed[10][-2:] == ["build", "--strict"]
+    assert executed[5][-2:] == ["check", "."]
+    assert executed[6][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "ruff"]
+    assert executed[6][-3:] == ["format", "--check", "."]
+    assert executed[7][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "mypy"]
+    assert executed[8][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "pytest"]
+    assert executed[9][:3] == ["uv", "run", "story-pipeline-canary"]
+    assert executed[9][-1] == "--strict"
+    assert executed[10][:3] == ["uv", "run", "story-qa-eval"]
+    assert executed[10][-2:] == ["--output", "work/qa/evaluation_summary.json"]
+    assert executed[11][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "mkdocs"]
+    assert executed[11][-2:] == ["build", "--strict"]
     assert ["npm", "run", "--prefix", "web", "typecheck"] in executed
     assert ["npm", "run", "--prefix", "web", "test:coverage"] in executed
     assert ["npm", "run", "--prefix", "web", "build"] in executed
@@ -105,7 +107,9 @@ def test_pre_push_checks_stops_on_command_failure(
     assert executed[2][0] == sys.executable
     assert executed[3][0] == sys.executable
     assert executed[3][-1].endswith("check_contract_drift.py")
-    assert executed[4][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "ruff"]
+    assert executed[4][:3] == ["uv", "run", "python"]
+    assert executed[4][-2:] == ["tools/export_openapi_snapshot.py", "--check"]
+    assert executed[5][:3] == [sys.executable, str(pre_push_checks.TOOL_RUNNER), "ruff"]
 
 
 def test_pre_push_checks_skips_clang_when_no_cpp_sources(

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -14,6 +14,8 @@ def test_makefile_contains_quality_and_native_targets() -> None:
     assert "hooks-run:" in makefile
     assert "quality:" in makefile
     assert "contracts-check:" in makefile
+    assert "openapi-export:" in makefile
+    assert "openapi-check:" in makefile
     assert "deploy: quality build-site" in makefile
     assert "cpp-configure:" in makefile
     assert "cpp-build:" in makefile
@@ -50,6 +52,7 @@ def test_makefile_contains_quality_and_native_targets() -> None:
     assert "pytest tests/test_e2e_stack.py" in makefile
     assert "import-check:" in makefile
     assert "quality: lock-check import-check" in makefile
+    assert "openapi-check" in makefile
     assert "frontend-quality:" in makefile
     assert "native-quality:" in makefile
     assert "web-coverage:" in makefile
@@ -74,6 +77,7 @@ def test_ci_workflow_includes_code_quality_steps() -> None:
     assert "uv run mkdocs build --strict" in workflow
     assert "uv run python tools/check_imports.py" in workflow
     assert "uv run python tools/check_contract_drift.py" in workflow
+    assert "uv run python tools/export_openapi_snapshot.py --check" in workflow
     assert "Configure CMake" in workflow
     assert "Run native tests" in workflow
     assert "Install native quality tools" in workflow
@@ -118,6 +122,7 @@ def test_deploy_workflow_requires_ci_success() -> None:
     assert "uv python install 3.11" in workflow
     assert "uv sync --group dev" in workflow
     assert "Build docs snapshot" in workflow
+    assert "uv run python tools/export_openapi_snapshot.py" in workflow
     assert "uv run mkdocs build --strict --site-dir docs_site" in workflow
     assert "Build Python API reference snapshot" in workflow
     assert "uv run python tools/build_python_api_docs.py --output-dir pydoc_site" in workflow
@@ -257,6 +262,7 @@ def test_mkdocs_configuration_exists() -> None:
     assert "0024 Dashboard Timeline and Heatmap Export Surfaces:" in config
     assert "0028 QA Evaluation Harness and Calibration Gates:" in config
     assert "0029 NLP Provider Resilience and Insight Calibration:" in config
+    assert "0030 OpenAPI Snapshot and Hosted API Reference:" in config
     assert "pymdownx.superfences" in config
     assert "mermaid.min.js" in config
     assert "javascripts/mermaid.js" in config
@@ -301,6 +307,8 @@ def test_pre_push_checks_include_docs_and_cpp_format() -> None:
     assert "docker executable not found in PATH" in checks
     assert '"story-qa-eval"' in checks
     assert '"work/qa/evaluation_summary.json"' in checks
+    assert '"tools/export_openapi_snapshot.py"' in checks
+    assert '"--check"' in checks
     assert 'run_tool("mkdocs", "build", "--strict")' in checks
     assert '"npm", "run", "--prefix", "web", "typecheck"' in checks
     assert '"npm", "run", "--prefix", "web", "test:coverage"' in checks
@@ -373,6 +381,7 @@ def test_architecture_docs_and_adr_scaffold_exist() -> None:
     assert (
         ROOT / "docs" / "adr" / "0029-nlp-provider-resilience-and-insight-calibration.md"
     ).exists()
+    assert (ROOT / "docs" / "adr" / "0030-openapi-snapshot-and-hosted-api-reference.md").exists()
     assert (ROOT / "docs" / "story_bundle.md").exists()
     assert (ROOT / "docs" / "observability.md").exists()
     assert (ROOT / "docs" / "graph_strategy.md").exists()
@@ -401,6 +410,7 @@ def test_api_docs_reference_swagger_and_openapi_endpoints() -> None:
     assert "http://127.0.0.1:8000/docs" in api_docs
     assert "http://127.0.0.1:8000/redoc" in api_docs
     assert "http://127.0.0.1:8000/openapi.json" in api_docs
+    assert "docs/assets/openapi/story_gen.openapi.json" in api_docs
     assert "https://ringxworld.github.io/story_generator/pydoc/" in api_docs
     assert "Authorize" in api_docs
     assert "http://127.0.0.1:8000/redoc" in setup_docs
@@ -417,6 +427,14 @@ def test_python_api_docs_builder_script_exists() -> None:
     assert "python tools/build_python_api_docs.py --output-dir pydoc_site" in _read(
         ".github/workflows/deploy-pages.yml"
     )
+
+
+def test_openapi_snapshot_builder_script_exists() -> None:
+    builder = _read("tools/export_openapi_snapshot.py")
+    assert "create_app" in builder
+    assert "--check" in builder
+    assert "python tools/export_openapi_snapshot.py --check" in _read(".github/workflows/ci.yml")
+    assert "python tools/export_openapi_snapshot.py" in _read(".github/workflows/deploy-pages.yml")
 
 
 def test_analysis_contract_scaffold_exists_and_is_valid_json() -> None:

--- a/tools/export_openapi_snapshot.py
+++ b/tools/export_openapi_snapshot.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Export FastAPI OpenAPI schema to a versioned JSON snapshot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from story_gen.api.app import create_app
+
+DEFAULT_OUTPUT = Path("docs/assets/openapi/story_gen.openapi.json")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export story_gen OpenAPI schema snapshot.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Path to write the OpenAPI JSON snapshot.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the snapshot on disk does not match generated OpenAPI output.",
+    )
+    return parser.parse_args()
+
+
+def _render(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    args = _parse_args()
+    output_path = args.output.resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    app = create_app()
+    generated = app.openapi()
+    rendered = _render(generated)
+
+    if args.check:
+        if not output_path.exists():
+            print(f"OpenAPI snapshot missing: {output_path}")
+            return 1
+        existing = _load_json(output_path)
+        if existing != generated:
+            print(
+                "OpenAPI snapshot drift detected. Run "
+                "`uv run python tools/export_openapi_snapshot.py`."
+            )
+            return 1
+        return 0
+
+    output_path.write_text(rendered, encoding="utf-8")
+    print(f"Wrote OpenAPI snapshot: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Move API docs to an OpenAPI-driven source of truth and publish a static schema-backed API reference in hosted docs.

## Linked Issues

- https://github.com/ringxworld/story_generator/issues/126

## Compact Mode (Small/Low-Risk Change)

### Change Notes

- Added `tools/export_openapi_snapshot.py` to export/check `create_app().openapi()`.
- Committed schema snapshot at `docs/assets/openapi/story_gen.openapi.json` and switched `docs/api.md` to render ReDoc from that snapshot.
- Added `make openapi-export` / `make openapi-check`, CI drift check, deploy-pages export step, and pre-push drift check.
- Added ADR `0030-openapi-snapshot-and-hosted-api-reference.md`.
- Expanded endpoint/client docstrings so Swagger/OpenAPI and pydoc surfaces carry meaningful descriptions.

### Validation

- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run python tools/export_openapi_snapshot.py --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- `uv run pytest`
- `uv run mkdocs build --strict`
- `uv run pre-commit run --all-files`
