### PR TITLE
Batch pipeline, Keycloak auth, Re:Zero demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ISSUE_SUMMARY_FILE ?=.github/ISSUE_CLOSE_SUMMARY_TEMPLATE.md
 
 .DEFAULT_GOAL := help
 
-.PHONY: help sync hooks-install hooks-run lock-check import-check contracts-check openapi-export openapi-check lint fix format format-check typecheck test e2e coverage quality frontend-quality native-quality check story pipeline-canary qa-eval build-site docs-serve story-page reference reference-translate collect-story video-story api blueprint features dev-stack dev-stack-hot stack-up stack-up-hot brand-icons docker-build docker-up docker-up-detached attach docker-down docker-logs docker-ci web-install web-dev web-hot web-typecheck web-test web-coverage web-build cpp-configure cpp-build cpp-test cpp-demo cpp-format cpp-format-check cpp-cppcheck wiki-sync wiki-sync-push contracts-export project-sync project-audit label-audit issue-close pr-open pr-checks pr-merge pr-auto deploy clean clean-deep
+.PHONY: help sync hooks-install hooks-run lock-check import-check contracts-check openapi-export openapi-check lint fix format format-check typecheck test e2e coverage quality frontend-quality native-quality check story pipeline-canary pipeline-batch qa-eval build-site docs-serve story-page reference reference-translate collect-story video-story api blueprint features dev-stack dev-stack-hot stack-up stack-up-hot brand-icons docker-build docker-up docker-up-detached attach docker-down docker-logs docker-ci web-install web-dev web-hot web-typecheck web-test web-coverage web-build cpp-configure cpp-build cpp-test cpp-demo cpp-format cpp-format-check cpp-cppcheck wiki-sync wiki-sync-push contracts-export project-sync project-audit label-audit issue-close pr-open pr-checks pr-merge pr-auto deploy clean clean-deep
 
 help:
 	@echo "story_gen targets:"
@@ -45,6 +45,7 @@ help:
 	@echo "  make check                - full local gate (python + frontend + native)"
 	@echo "  make story                - run the story_gen CLI"
 	@echo "  make pipeline-canary      - run end-to-end ingest->insights pipeline canary"
+	@echo "  make pipeline-batch       - run batch pipeline over chapter files"
 	@echo "  make qa-eval              - run fixture-driven QA evaluation harness"
 	@echo "  make build-site           - build MkDocs pages site"
 	@echo "  make docs-serve           - serve MkDocs locally"
@@ -158,6 +159,9 @@ story:
 
 pipeline-canary:
 	$(RUN) story-pipeline-canary --strict
+
+pipeline-batch:
+	$(RUN) story-pipeline-batch --source-dir work/resources/re_zero/n2267be/chapters --run-id re-zero
 
 qa-eval:
 	$(RUN) story-qa-eval --strict --output work/qa/evaluation_summary.json

--- a/docs/adr/0031-keycloak-oidc-auth.md
+++ b/docs/adr/0031-keycloak-oidc-auth.md
@@ -1,0 +1,36 @@
+# 0031 Keycloak OIDC Authentication
+
+## Problem
+
+The API currently ships with local bearer-token auth, but production use needs
+integration with an external identity provider. We need a supported path for
+Keycloak-backed OpenID Connect (OIDC) without changing the core API contract.
+
+## Non-goals
+
+- Replacing FastAPI auth primitives or rewriting the auth model.
+- Implementing OAuth authorization code flows inside the API itself.
+- Handling token refresh or session management on the backend.
+
+## Public API
+
+- `STORY_GEN_AUTH_MODE=keycloak` switches the API to OIDC validation mode.
+- `STORY_GEN_OIDC_ISSUER` sets the issuer URL (required).
+- `STORY_GEN_OIDC_AUDIENCE` sets the expected audience (optional).
+- `STORY_GEN_OIDC_JWKS_URL` overrides JWKS discovery (optional).
+- `STORY_GEN_OIDC_JWKS_JSON` allows inline JWKS for offline/dev use (optional).
+
+`/api/v1/auth/register` and `/api/v1/auth/login` return HTTP 501 in Keycloak mode.
+
+## Invariants
+
+- When `STORY_GEN_AUTH_MODE=keycloak`, requests without a valid bearer token are
+  rejected with HTTP 401.
+- Tokens are validated against issuer, JWKS, and optional audience.
+- No raw tokens are persisted in the database.
+- Local auth remains the default when `STORY_GEN_AUTH_MODE` is not set.
+
+## Test plan
+
+- `uv run pytest tests/test_api_app.py -k keycloak`
+- `uv run pytest tests/test_api_app.py -k register`

--- a/docs/adr/0032-batch-pipeline-re-zero-benchmark.md
+++ b/docs/adr/0032-batch-pipeline-re-zero-benchmark.md
@@ -1,0 +1,33 @@
+# 0032 Batch Pipeline and Re:Zero Benchmark
+
+## Problem
+
+We need a reliable, apples-to-apples benchmark for end-to-end pipeline runs
+across large chapter sets. The existing canary is valuable but does not capture
+translation reliability, batch throughput, or chapter-by-chapter failure modes.
+
+## Non-goals
+
+- Shipping or committing third-party full text into the repository.
+- Changing the core pipeline architecture or schema versions.
+- Adding online translation dependencies as required defaults.
+
+## Public API
+
+- New CLI: `story-pipeline-batch`
+- Batch outputs written to `work/pipeline_runs/<run-id>/` with:
+  - `summary.json` (overall timings and counts)
+  - `chapters/*.json` (per-chapter analysis summaries)
+  - `translated_en/*.txt` (optional translated chapter text)
+
+## Invariants
+
+- Batch pipeline never commits source text into the repo.
+- Offline translation paths are supported via optional dependencies.
+- Timing metrics are always emitted for batch runs.
+- Failure in one chapter does not halt the batch unless `--strict` is set.
+
+## Test plan
+
+- `uv run pytest tests/test_pipeline_batch.py`
+- `uv run pytest tests/test_cli_entrypoints.py -k pipeline_batch`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,3 +28,5 @@ Latest ADR:
 - `0028-qa-evaluation-harness-and-calibration-gates.md`
 - `0029-nlp-provider-resilience-and-insight-calibration.md`
 - `0030-openapi-snapshot-and-hosted-api-reference.md`
+- `0031-keycloak-oidc-auth.md`
+- `0032-batch-pipeline-re-zero-benchmark.md`

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,26 @@ uv run story-api --db-path work/local/story_gen.db
 3. Click **Authorize** in Swagger UI and paste `Bearer <token>`.
 4. Execute owner-scoped routes (`/stories/*`, `/essays/*`).
 
+## Keycloak (OIDC) mode
+
+When `STORY_GEN_AUTH_MODE=keycloak`, the API validates bearer tokens against
+the configured OIDC issuer and JWKS endpoint. Local `/auth/register` and
+`/auth/login` endpoints return HTTP 501 in this mode.
+
+Required environment variables:
+
+- `STORY_GEN_AUTH_MODE=keycloak`
+- `STORY_GEN_OIDC_ISSUER=https://<keycloak-host>/realms/<realm>`
+
+Optional:
+
+- `STORY_GEN_OIDC_AUDIENCE=<client-id>`
+- `STORY_GEN_OIDC_JWKS_URL=<override jwks endpoint>`
+- `STORY_GEN_OIDC_JWKS_JSON=<inline jwks for offline/dev>`
+
+In Swagger UI, click **Authorize** and paste `Bearer <access_token>` from
+Keycloak.
+
 ## Keep docs current
 
 Generate the committed OpenAPI snapshot used by docs:

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -188,6 +188,14 @@ uv sync --group topic
 uv sync --group advanced
 ```
 
+## 7.1 Optional translation dependencies
+
+Offline translation uses Argos Translate:
+
+```bash
+uv sync --group translation
+```
+
 ## 8. Optional cloud compose scaffolds
 
 If you want to smoke-test deployment shapes locally:
@@ -249,3 +257,10 @@ Web cannot reach API
 - Confirm API is running on `127.0.0.1:8000`.
 - Verify `VITE_API_BASE_URL`.
 - Check CORS origins in `STORY_GEN_CORS_ORIGINS` if customized.
+
+Keycloak auth issues
+
+- Set `STORY_GEN_AUTH_MODE=keycloak`.
+- Set `STORY_GEN_OIDC_ISSUER` to the realm issuer URL.
+- If JWKS discovery fails, set `STORY_GEN_OIDC_JWKS_URL` or inline
+  `STORY_GEN_OIDC_JWKS_JSON`.

--- a/docs/lessons_learned/re_zero_e2e.md
+++ b/docs/lessons_learned/re_zero_e2e.md
@@ -1,0 +1,35 @@
+# Re:Zero End-to-End Lessons Learned
+
+This write-up captures the practical issues observed while running a full
+Re:Zero chapter pipeline and the improvements baked into the current tooling.
+
+## What went wrong
+
+- Rate limiting and throttling from remote translation services caused retries,
+  empty output, and long end-to-end execution times.
+- Some translation responses returned empty strings or output dominated by
+  placeholder characters.
+- Long chapters exceeded single-request size limits.
+- A lack of per-chapter timing made it hard to compare runs apples-to-apples.
+
+## What we changed
+
+- Added a batch pipeline runner with per-chapter summaries and timing totals.
+- Added translation retry + backoff handling for 429/503 responses.
+- Added an offline translation option (`argostranslate`) that avoids external
+  rate limits when installed.
+- Added output summaries for pipeline duration and per-stage timing to improve
+  comparability across runs.
+
+## Reliability guidance
+
+- Prefer offline translation when possible for large batch runs.
+- Use chunked translation and apply delay between requests to keep APIs stable.
+- Track `summary.json` timing totals after each run and compare against prior
+  runs using the same chapter set.
+
+## Next improvements
+
+- Add translation quality scoring to highlight low-confidence chapters.
+- Improve retry logic to include circuit breaking when throttling is sustained.
+- Add regression baselines for large story sets under `work/pipeline_runs/`.

--- a/docs/reference_pipeline.md
+++ b/docs/reference_pipeline.md
@@ -27,6 +27,37 @@ uv run story-reference \
   --max-episodes 3
 ```
 
+## Offline translation
+
+Install the optional group:
+
+```bash
+uv sync --group translation
+```
+
+Then run with:
+
+```bash
+uv run story-reference --translate-provider argos --max-episodes 3
+```
+
+Use `--translate-provider chain` to try Argos first and fall back to LibreTranslate.
+
+## Batch pipeline runner
+
+For chapter text files on disk, use the batch pipeline:
+
+```bash
+uv run story-pipeline-batch \
+  --source-dir work/resources/re_zero/n2267be/chapters \
+  --run-id re-zero \
+  --translate-provider none \
+  --mode analyze
+```
+
+Outputs land in `work/pipeline_runs/re-zero/` with per-chapter summaries and a
+`summary.json` timing report.
+
 ## Focus names for character tracking
 
 Edit:

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -11,7 +11,9 @@ GitHub Pages now publishes a static offline demo build of the studio at:
 - `https://ringxworld.github.io/story_generator/studio/`
 
 This mode does not call the backend. It renders representative story analysis
-dashboard data so visitors can explore the UX end-to-end.
+dashboard data so visitors can explore the UX end-to-end. The overview card
+metrics are seeded from the Re:Zero batch pipeline summary to reflect a real
+large-story run.
 
 Theme behavior:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,9 +81,12 @@ nav:
       - 0028 QA Evaluation Harness and Calibration Gates: adr/0028-qa-evaluation-harness-and-calibration-gates.md
       - 0029 NLP Provider Resilience and Insight Calibration: adr/0029-nlp-provider-resilience-and-insight-calibration.md
       - 0030 OpenAPI Snapshot and Hosted API Reference: adr/0030-openapi-snapshot-and-hosted-api-reference.md
+      - 0031 Keycloak OIDC Auth: adr/0031-keycloak-oidc-auth.md
+      - 0032 Batch Pipeline Re:Zero Benchmark: adr/0032-batch-pipeline-re-zero-benchmark.md
   - Guides:
       - Dependency Charts: dependency_charts.md
       - Reference Pipeline: reference_pipeline.md
+      - Lessons Learned (Re:Zero E2E): lessons_learned/re_zero_e2e.md
       - GitHub Collaboration: github_collaboration.md
       - Native C++: native_cpp.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
   "beautifulsoup4>=4.12.3",
   "fastapi>=0.116.1",
   "httpx>=0.28.1",
+  "pyjwt>=2.9.0",
+  "cryptography>=42.0.0",
   "pydantic>=2.11.7",
   "uvicorn>=0.35.0",
 ]
@@ -27,6 +29,7 @@ story-features = "story_gen.cli.features:main"
 story-dashboard-export = "story_gen.cli.dashboard_export:main"
 story-pipeline-canary = "story_gen.cli.pipeline_canary:main"
 story-qa-eval = "story_gen.cli.qa_evaluation:main"
+story-pipeline-batch = "story_gen.cli.pipeline_batch:main"
 
 [dependency-groups]
 dev = [
@@ -53,6 +56,9 @@ topic = [
 ]
 advanced = [
   "stanza>=1.8.0",
+]
+translation = [
+  "argostranslate>=1.9.6",
 ]
 
 [tool.uv]

--- a/src/story_gen/api/app.py
+++ b/src/story_gen/api/app.py
@@ -66,6 +66,7 @@ from story_gen.api.contracts import (
     StoryUpdateRequest,
     UserResponse,
 )
+from story_gen.api.oidc import OidcClaims, validate_oidc_token
 from story_gen.core.dashboard_views import (
     GraphEdge,
     GraphNode,
@@ -91,7 +92,6 @@ from story_gen.core.story_feature_pipeline import (
 )
 from story_gen.core.story_ingestion import IngestionRequest, ingest_story_text
 from story_gen.core.story_schema import StoryDocument, StoryStage
-from story_gen.api.oidc import OidcClaims, validate_oidc_token
 
 DEFAULT_DB_PATH = Path("work/local/story_gen.db")
 TOKEN_TTL_HOURS = 24

--- a/src/story_gen/api/app.py
+++ b/src/story_gen/api/app.py
@@ -91,6 +91,7 @@ from story_gen.core.story_feature_pipeline import (
 )
 from story_gen.core.story_ingestion import IngestionRequest, ingest_story_text
 from story_gen.core.story_schema import StoryDocument, StoryStage
+from story_gen.api.oidc import OidcClaims, validate_oidc_token
 
 DEFAULT_DB_PATH = Path("work/local/story_gen.db")
 TOKEN_TTL_HOURS = 24
@@ -183,6 +184,13 @@ def _int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
+
+
+def _auth_mode() -> str:
+    raw = os.environ.get("STORY_GEN_AUTH_MODE", "local").strip().lower()
+    if raw in {"keycloak", "oidc"}:
+        return "keycloak"
+    return "local"
 
 
 def _hash_password(password: str) -> str:
@@ -638,6 +646,17 @@ def create_app(db_path: Path | None = None) -> FastAPI:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Missing bearer token",
             )
+        if _auth_mode() == "keycloak":
+            try:
+                return _user_from_oidc_token(credentials.credentials, store)
+            except HTTPException:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("oidc.auth_failed error=%s", exc)
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid or expired token",
+                ) from exc
         user = store.get_user_by_token(
             token_value=credentials.credentials, now_utc=_utc_now().isoformat()
         )
@@ -647,6 +666,33 @@ def create_app(db_path: Path | None = None) -> FastAPI:
                 detail="Invalid or expired token",
             )
         return user
+
+    def _user_from_oidc_token(token: str, store: SQLiteStoryStore) -> StoredUser:
+        claims = validate_oidc_token(token)
+        email = _oidc_email(claims)
+        display_name = _oidc_display_name(claims)
+        existing = store.get_user_by_email(email=email)
+        if existing is not None:
+            return existing
+        created = store.create_user(
+            email=email,
+            display_name=display_name,
+            password_hash=_hash_password(secrets.token_urlsafe(32)),
+        )
+        if created is None:
+            existing = store.get_user_by_email(email=email)
+            if existing is not None:
+                return existing
+            raise HTTPException(status_code=500, detail="OIDC user provisioning failed")
+        return created
+
+    def _oidc_email(claims: OidcClaims) -> str:
+        if claims.email:
+            return claims.email
+        return f"{claims.subject}@oidc.local"
+
+    def _oidc_display_name(claims: OidcClaims) -> str:
+        return claims.preferred_username or claims.name or claims.email or claims.subject
 
     @app.get("/healthz", response_model=HealthResponse, tags=["system"])
     def healthz() -> HealthResponse:
@@ -661,6 +707,11 @@ def create_app(db_path: Path | None = None) -> FastAPI:
     @app.post("/api/v1/auth/register", response_model=UserResponse, tags=["auth"], status_code=201)
     def register(payload: AuthRegisterRequest) -> UserResponse:
         """Create a local user account for bearer-token authentication."""
+        if _auth_mode() == "keycloak":
+            raise HTTPException(
+                status_code=501,
+                detail="Local registration is disabled when auth mode is keycloak.",
+            )
         created = store.create_user(
             email=payload.email,
             display_name=payload.display_name.strip(),
@@ -673,6 +724,11 @@ def create_app(db_path: Path | None = None) -> FastAPI:
     @app.post("/api/v1/auth/login", response_model=AuthTokenResponse, tags=["auth"])
     def login(payload: AuthLoginRequest) -> AuthTokenResponse:
         """Authenticate credentials and issue a time-limited bearer token."""
+        if _auth_mode() == "keycloak":
+            raise HTTPException(
+                status_code=501,
+                detail="Local login is disabled when auth mode is keycloak.",
+            )
         user = store.get_user_by_email(email=payload.email)
         if user is None or not _verify_password(
             payload.password.get_secret_value(), user.password_hash

--- a/src/story_gen/api/oidc.py
+++ b/src/story_gen/api/oidc.py
@@ -1,0 +1,158 @@
+"""OpenID Connect token validation helpers for Keycloak-backed auth."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import jwt
+
+
+@dataclass(frozen=True)
+class OidcClaims:
+    """Verified OIDC claims used by API auth."""
+
+    subject: str
+    issuer: str
+    email: str | None
+    preferred_username: str | None
+    name: str | None
+    audience: str | None
+
+
+@dataclass
+class _OidcCache:
+    value: dict[str, Any] | None = None
+    expires_at: float = 0.0
+
+
+_JWKS_CACHE = _OidcCache()
+_WELL_KNOWN_CACHE = _OidcCache()
+
+
+def _env(name: str, default: str = "") -> str:
+    return str((__import__("os")).environ.get(name, default)).strip()
+
+
+def _int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = _env(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _resolve_jwks_url(issuer: str) -> str:
+    explicit = _env("STORY_GEN_OIDC_JWKS_URL")
+    if explicit:
+        return explicit
+    well_known = _fetch_well_known(issuer)
+    jwks_uri = well_known.get("jwks_uri")
+    if isinstance(jwks_uri, str) and jwks_uri:
+        return jwks_uri
+    raise RuntimeError("OIDC well-known config missing jwks_uri.")
+
+
+def _fetch_well_known(issuer: str) -> dict[str, Any]:
+    ttl_seconds = _int_env("STORY_GEN_OIDC_WELL_KNOWN_TTL_SECONDS", 300, minimum=30, maximum=3600)
+    now = time.monotonic()
+    if _WELL_KNOWN_CACHE.value is not None and _WELL_KNOWN_CACHE.expires_at > now:
+        return _WELL_KNOWN_CACHE.value
+    url = issuer.rstrip("/") + "/.well-known/openid-configuration"
+    with httpx.Client(timeout=10.0, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("OIDC well-known response was not an object.")
+    _WELL_KNOWN_CACHE.value = payload
+    _WELL_KNOWN_CACHE.expires_at = now + ttl_seconds
+    return payload
+
+
+def _fetch_jwks(issuer: str) -> dict[str, Any]:
+    inline = _env("STORY_GEN_OIDC_JWKS_JSON")
+    if inline:
+        payload = json.loads(inline)
+        if not isinstance(payload, dict):
+            raise RuntimeError("OIDC JWKS JSON must be an object.")
+        return payload
+    ttl_seconds = _int_env("STORY_GEN_OIDC_JWKS_TTL_SECONDS", 300, minimum=30, maximum=3600)
+    now = time.monotonic()
+    if _JWKS_CACHE.value is not None and _JWKS_CACHE.expires_at > now:
+        return _JWKS_CACHE.value
+    jwks_url = _resolve_jwks_url(issuer)
+    with httpx.Client(timeout=10.0, follow_redirects=True) as client:
+        response = client.get(jwks_url)
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("OIDC JWKS response was not an object.")
+    _JWKS_CACHE.value = payload
+    _JWKS_CACHE.expires_at = now + ttl_seconds
+    return payload
+
+
+def _select_jwk(jwks: dict[str, Any], kid: str | None) -> dict[str, Any]:
+    keys = jwks.get("keys")
+    if not isinstance(keys, list):
+        raise RuntimeError("OIDC JWKS payload missing keys list.")
+    if kid is None:
+        if len(keys) == 1 and isinstance(keys[0], dict):
+            return keys[0]
+        raise RuntimeError("OIDC token header missing kid and JWKS has multiple keys.")
+    for key in keys:
+        if isinstance(key, dict) and key.get("kid") == kid:
+            return key
+    raise RuntimeError("OIDC JWKS did not contain signing key for token kid.")
+
+
+def validate_oidc_token(token: str) -> OidcClaims:
+    """Validate a bearer token against OIDC settings."""
+    issuer = _env("STORY_GEN_OIDC_ISSUER")
+    if not issuer:
+        raise RuntimeError("STORY_GEN_OIDC_ISSUER is required for keycloak auth.")
+    audience = _env("STORY_GEN_OIDC_AUDIENCE")
+    algorithms = _env("STORY_GEN_OIDC_ALGORITHMS", "RS256").split(",")
+    algorithms = [algo.strip() for algo in algorithms if algo.strip()]
+    if not algorithms:
+        algorithms = ["RS256"]
+
+    header = jwt.get_unverified_header(token)
+    kid = header.get("kid") if isinstance(header, dict) else None
+    jwks = _fetch_jwks(issuer)
+    jwk = _select_jwk(jwks, kid)
+    public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+    options = {"verify_aud": bool(audience)}
+    payload = jwt.decode(
+        token,
+        key=public_key,
+        algorithms=algorithms,
+        audience=audience or None,
+        issuer=issuer,
+        options=options,
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("OIDC token payload was not an object.")
+    subject = payload.get("sub")
+    if not isinstance(subject, str) or not subject.strip():
+        raise RuntimeError("OIDC token missing subject.")
+    email = payload.get("email")
+    preferred_username = payload.get("preferred_username")
+    name = payload.get("name")
+    return OidcClaims(
+        subject=subject,
+        issuer=issuer,
+        email=email if isinstance(email, str) and email.strip() else None,
+        preferred_username=preferred_username
+        if isinstance(preferred_username, str) and preferred_username.strip()
+        else None,
+        name=name if isinstance(name, str) and name.strip() else None,
+        audience=audience or None,
+    )

--- a/src/story_gen/cli/pipeline_batch.py
+++ b/src/story_gen/cli/pipeline_batch.py
@@ -1,0 +1,463 @@
+"""Batch pipeline runner for chapter directories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+
+from story_gen.core.story_analysis_pipeline import run_story_analysis
+from story_gen.core.story_schema import StoryDocument
+
+
+@dataclass(frozen=True)
+class ChapterSummary:
+    chapter_number: int
+    source_path: str
+    translated: bool
+    translation_provider: str
+    source_language: str
+    source_chars: int
+    translated_chars: int
+    event_count: int
+    beat_count: int
+    theme_count: int
+    insight_count: int
+    top_entities: list[str]
+    top_themes: list[str]
+    quality_passed: bool
+    translation_quality: float
+    timing_seconds: dict[str, float]
+
+
+@dataclass(frozen=True)
+class BatchSummary:
+    run_id: str
+    started_at_utc: str
+    finished_at_utc: str
+    total_chapters: int
+    processed_chapters: int
+    skipped_chapters: int
+    failed_chapters: int
+    failures: list[dict[str, object]]
+    elapsed_seconds: float
+    average_chapter_seconds: float
+    translation_provider: str
+    timing_totals: dict[str, float]
+
+
+class TranslationError(RuntimeError):
+    """Raised when translation fails for a chapter."""
+
+
+class ArgosTranslator:
+    name = "argos.v1"
+
+    def __init__(self, source_language: str, target_language: str) -> None:
+        try:
+            import argostranslate.translate as argos_translate  # type: ignore
+        except Exception as exc:  # noqa: BLE001
+            raise TranslationError("argostranslate is not installed") from exc
+        languages = argos_translate.get_installed_languages()
+        source = next((lang for lang in languages if lang.code == source_language), None)
+        target = next((lang for lang in languages if lang.code == target_language), None)
+        if source is None or target is None:
+            raise TranslationError(
+                f"argostranslate missing language pair {source_language}->{target_language}"
+            )
+        self._translator = source.get_translation(target)
+
+    def translate(self, text: str) -> str:
+        return self._translator.translate(text)
+
+
+class LibreTranslateClient:
+    name = "libretranslate.v1"
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        source_language: str,
+        target_language: str,
+        api_key: str | None,
+        delay_seconds: float,
+        chunk_size: int,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._source_language = source_language
+        self._target_language = target_language
+        self._api_key = api_key
+        self._delay_seconds = delay_seconds
+        self._chunk_size = chunk_size
+
+    def translate(self, text: str) -> str:
+        if not text.strip():
+            return ""
+        chunks = _chunk_text(text, self._chunk_size)
+        translated: list[str] = []
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            for index, chunk in enumerate(chunks, start=1):
+                translated.append(
+                    _translate_with_retry(
+                        client=client,
+                        base_url=self._base_url,
+                        text=chunk,
+                        source_language=self._source_language,
+                        target_language=self._target_language,
+                        api_key=self._api_key,
+                    )
+                )
+                if index < len(chunks) and self._delay_seconds > 0:
+                    time.sleep(self._delay_seconds)
+        return "\n\n".join(translated).strip()
+
+
+def _translate_with_retry(
+    *,
+    client: httpx.Client,
+    base_url: str,
+    text: str,
+    source_language: str,
+    target_language: str,
+    api_key: str | None,
+) -> str:
+    last_error: Exception | None = None
+    for attempt in range(1, 6):
+        try:
+            payload: dict[str, object] = {
+                "q": text,
+                "source": source_language,
+                "target": target_language,
+                "format": "text",
+            }
+            if api_key:
+                payload["api_key"] = api_key
+            response = client.post(f"{base_url}/translate", json=payload)
+            if response.status_code in {429, 503}:
+                raise TranslationError(f"LibreTranslate throttled: {response.status_code}")
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, dict):
+                raise TranslationError("LibreTranslate response was not an object")
+            translated = data.get("translatedText")
+            if not isinstance(translated, str) or not translated.strip():
+                raise TranslationError("LibreTranslate response missing translatedText")
+            return translated.strip()
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(min(8.0, 0.6 * attempt))
+    if last_error is not None:
+        raise TranslationError(str(last_error)) from last_error
+    raise TranslationError("LibreTranslate failed without error detail")
+
+
+def _chunk_text(text: str, max_chars: int) -> list[str]:
+    paragraphs = [part.strip() for part in text.split("\n\n") if part.strip()]
+    if not paragraphs:
+        return [text]
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_len = 0
+
+    for paragraph in paragraphs:
+        if len(paragraph) > max_chars:
+            if current:
+                chunks.append("\n\n".join(current))
+                current = []
+                current_len = 0
+            for i in range(0, len(paragraph), max_chars):
+                chunks.append(paragraph[i : i + max_chars])
+            continue
+
+        projected = current_len + len(paragraph) + (2 if current else 0)
+        if current and projected > max_chars:
+            chunks.append("\n\n".join(current))
+            current = [paragraph]
+            current_len = len(paragraph)
+            continue
+
+        current.append(paragraph)
+        current_len = projected
+
+    if current:
+        chunks.append("\n\n".join(current))
+    return chunks
+
+
+def _looks_untranslated(source: str, translated: str) -> bool:
+    if not translated.strip():
+        return True
+    source_has_jp = sum(1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff")
+    if source_has_jp == 0:
+        return False
+    translated_ascii = sum(1 for ch in translated if "a" <= ch.lower() <= "z")
+    unknown_ratio = translated.count("?") / max(1, len(translated))
+    return translated_ascii < 10 or unknown_ratio > 0.2
+
+
+def _translator_chain(
+    *,
+    provider: str,
+    source_language: str,
+    target_language: str,
+    libretranslate_url: str,
+    libretranslate_api_key: str | None,
+    translate_delay_seconds: float,
+    translate_chunk_size: int,
+) -> list[object]:
+    if provider == "none":
+        return []
+    chain: list[object] = []
+    if provider in {"argos", "chain"}:
+        try:
+            chain.append(ArgosTranslator(source_language, target_language))
+        except TranslationError:
+            if provider == "argos":
+                raise
+    if provider in {"libretranslate", "chain"}:
+        chain.append(
+            LibreTranslateClient(
+                base_url=libretranslate_url,
+                source_language=source_language,
+                target_language=target_language,
+                api_key=libretranslate_api_key,
+                delay_seconds=translate_delay_seconds,
+                chunk_size=translate_chunk_size,
+            )
+        )
+    return chain
+
+
+def _translate_text(
+    *,
+    source_text: str,
+    chain: list[object],
+) -> tuple[str, str]:
+    if not chain:
+        return source_text, "none"
+    last_error: Exception | None = None
+    for translator in chain:
+        name = getattr(translator, "name", "unknown")
+        try:
+            translated = translator.translate(source_text)
+            if _looks_untranslated(source_text, translated):
+                raise TranslationError(f"{name} produced low-quality output")
+            return translated, name
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            continue
+    if last_error is not None:
+        raise TranslationError(str(last_error)) from last_error
+    raise TranslationError("translation failed")
+
+
+def _chapter_number(path: Path) -> int:
+    stem = path.stem
+    try:
+        return int(stem)
+    except ValueError:
+        return 0
+
+
+def _summarize_document(document: StoryDocument) -> tuple[list[str], list[str]]:
+    entities = sorted(
+        document.entity_mentions, key=lambda ent: (-ent.mention_count, ent.name)
+    )
+    themes = sorted(
+        document.theme_signals, key=lambda theme: (-theme.intensity, theme.theme)
+    )
+    top_entities = [entity.name for entity in entities[:6]]
+    top_themes = [theme.theme for theme in themes[:6]]
+    return top_entities, top_themes
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def run_pipeline_batch(args: argparse.Namespace) -> BatchSummary:
+    source_dir = Path(args.source_dir)
+    output_root = Path(args.output_dir) / args.run_id
+    output_root.mkdir(parents=True, exist_ok=True)
+    summaries_dir = output_root / "chapters"
+    summaries_dir.mkdir(parents=True, exist_ok=True)
+    translated_dir = Path(args.translated_dir) if args.translated_dir else output_root / "translated_en"
+    translated_dir.mkdir(parents=True, exist_ok=True)
+
+    chain = _translator_chain(
+        provider=args.translate_provider,
+        source_language=args.source_language,
+        target_language=args.target_language,
+        libretranslate_url=args.libretranslate_url,
+        libretranslate_api_key=args.libretranslate_api_key or None,
+        translate_delay_seconds=args.translate_delay_seconds,
+        translate_chunk_size=args.translate_chunk_size,
+    )
+
+    files = sorted(source_dir.glob("*.txt"), key=_chapter_number)
+    filtered: list[Path] = []
+    for path in files:
+        number = _chapter_number(path)
+        if number < args.chapter_start:
+            continue
+        if args.chapter_end and number > args.chapter_end:
+            continue
+        filtered.append(path)
+    if args.max_chapters:
+        filtered = filtered[: args.max_chapters]
+
+    started = time.perf_counter()
+    started_at = datetime.now(UTC).isoformat()
+    processed = 0
+    skipped = 0
+    failed = 0
+    failures: list[dict[str, object]] = []
+    timing_totals: dict[str, float] = {}
+
+    for path in filtered:
+        number = _chapter_number(path)
+        summary_path = summaries_dir / f"{number:04d}.json"
+        if summary_path.exists() and not args.force:
+            skipped += 1
+            continue
+
+        try:
+            raw_text = path.read_text(encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            failures.append({"chapter_number": number, "stage": "read", "error": str(exc)})
+            if args.strict:
+                raise
+            continue
+
+        translated_text = raw_text
+        translated = False
+        provider_used = "none"
+        if args.mode in {"translate", "all"} and args.translate_provider != "none":
+            try:
+                translated_text, provider_used = _translate_text(
+                    source_text=raw_text, chain=chain
+                )
+                translated = provider_used != "none"
+                translated_path = translated_dir / path.name
+                translated_path.write_text(translated_text + "\n", encoding="utf-8")
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                failures.append(
+                    {"chapter_number": number, "stage": "translate", "error": str(exc)}
+                )
+                if args.strict:
+                    raise
+                continue
+        elif args.mode in {"analyze", "all"} and translated_dir.exists():
+            translated_path = translated_dir / path.name
+            if translated_path.exists():
+                translated_text = translated_path.read_text(encoding="utf-8")
+                translated = True
+
+        if args.mode in {"translate"}:
+            processed += 1
+            continue
+
+        try:
+            analysis = run_story_analysis(
+                story_id=f"{args.story_id_prefix}{number:04d}",
+                source_text=translated_text,
+                source_type="text",
+                target_language=args.target_language,
+            )
+            top_entities, top_themes = _summarize_document(analysis.document)
+            summary = ChapterSummary(
+                chapter_number=number,
+                source_path=str(path),
+                translated=translated,
+                translation_provider=provider_used,
+                source_language=analysis.document.source_language,
+                source_chars=len(raw_text),
+                translated_chars=len(translated_text),
+                event_count=len(analysis.document.extracted_events),
+                beat_count=len(analysis.document.story_beats),
+                theme_count=len(analysis.document.theme_signals),
+                insight_count=len(analysis.document.insights),
+                top_entities=top_entities,
+                top_themes=top_themes,
+                quality_passed=analysis.document.quality_gate.passed,
+                translation_quality=analysis.document.quality_gate.translation_quality,
+                timing_seconds=analysis.timing,
+            )
+            _write_json(summary_path, asdict(summary))
+            processed += 1
+            for key, value in analysis.timing.items():
+                timing_totals[key] = timing_totals.get(key, 0.0) + value
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            failures.append({"chapter_number": number, "stage": "analyze", "error": str(exc)})
+            if args.strict:
+                raise
+
+    finished_at = datetime.now(UTC).isoformat()
+    elapsed = time.perf_counter() - started
+    average = elapsed / processed if processed else 0.0
+    summary = BatchSummary(
+        run_id=args.run_id,
+        started_at_utc=started_at,
+        finished_at_utc=finished_at,
+        total_chapters=len(filtered),
+        processed_chapters=processed,
+        skipped_chapters=skipped,
+        failed_chapters=failed,
+        failures=failures,
+        elapsed_seconds=round(elapsed, 2),
+        average_chapter_seconds=round(average, 2),
+        translation_provider=args.translate_provider,
+        timing_totals={key: round(value, 3) for key, value in timing_totals.items()},
+    )
+    _write_json(output_root / "summary.json", asdict(summary))
+    return summary
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run story analysis in batch over chapter files.")
+    parser.add_argument("--source-dir", required=True)
+    parser.add_argument("--output-dir", default="work/pipeline_runs")
+    parser.add_argument("--run-id", default="batch-run")
+    parser.add_argument("--translated-dir", default="")
+    parser.add_argument("--chapter-start", type=int, default=1)
+    parser.add_argument("--chapter-end", type=int, default=0)
+    parser.add_argument("--max-chapters", type=int, default=0)
+    parser.add_argument("--translate-provider", choices=["none", "argos", "libretranslate", "chain"], default="chain")
+    parser.add_argument("--source-language", default="ja")
+    parser.add_argument("--target-language", default="en")
+    parser.add_argument("--libretranslate-url", default="http://localhost:5000")
+    parser.add_argument("--libretranslate-api-key", default="")
+    parser.add_argument("--translate-delay-seconds", type=float, default=0.35)
+    parser.add_argument("--translate-chunk-size", type=int, default=1800)
+    parser.add_argument("--mode", choices=["translate", "analyze", "all"], default="all")
+    parser.add_argument("--story-id-prefix", default="chapter-")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--strict", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if not args.run_id.strip():
+        args.run_id = "batch-run"
+    args.chapter_start = max(1, int(args.chapter_start))
+    args.chapter_end = int(args.chapter_end) if int(args.chapter_end) > 0 else 0
+    args.max_chapters = int(args.max_chapters) if int(args.max_chapters) > 0 else 0
+    args.translated_dir = str(args.translated_dir).strip()
+    run_pipeline_batch(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/story_gen/cli/pipeline_batch.py
+++ b/src/story_gen/cli/pipeline_batch.py
@@ -194,7 +194,9 @@ def _chunk_text(text: str, max_chars: int) -> list[str]:
 def _looks_untranslated(source: str, translated: str) -> bool:
     if not translated.strip():
         return True
-    source_has_jp = sum(1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff")
+    source_has_jp = sum(
+        1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff"
+    )
     if source_has_jp == 0:
         return False
     translated_ascii = sum(1 for ch in translated if "a" <= ch.lower() <= "z")
@@ -267,12 +269,8 @@ def _chapter_number(path: Path) -> int:
 
 
 def _summarize_document(document: StoryDocument) -> tuple[list[str], list[str]]:
-    entities = sorted(
-        document.entity_mentions, key=lambda ent: (-ent.mention_count, ent.name)
-    )
-    themes = sorted(
-        document.theme_signals, key=lambda theme: (-theme.intensity, theme.theme)
-    )
+    entities = sorted(document.entity_mentions, key=lambda ent: (-ent.mention_count, ent.name))
+    themes = sorted(document.theme_signals, key=lambda theme: (-theme.intensity, theme.theme))
     top_entities = [entity.name for entity in entities[:6]]
     top_themes = [theme.theme for theme in themes[:6]]
     return top_entities, top_themes
@@ -289,7 +287,9 @@ def run_pipeline_batch(args: argparse.Namespace) -> BatchSummary:
     output_root.mkdir(parents=True, exist_ok=True)
     summaries_dir = output_root / "chapters"
     summaries_dir.mkdir(parents=True, exist_ok=True)
-    translated_dir = Path(args.translated_dir) if args.translated_dir else output_root / "translated_en"
+    translated_dir = (
+        Path(args.translated_dir) if args.translated_dir else output_root / "translated_en"
+    )
     translated_dir.mkdir(parents=True, exist_ok=True)
 
     chain = _translator_chain(
@@ -343,17 +343,13 @@ def run_pipeline_batch(args: argparse.Namespace) -> BatchSummary:
         provider_used = "none"
         if args.mode in {"translate", "all"} and args.translate_provider != "none":
             try:
-                translated_text, provider_used = _translate_text(
-                    source_text=raw_text, chain=chain
-                )
+                translated_text, provider_used = _translate_text(source_text=raw_text, chain=chain)
                 translated = provider_used != "none"
                 translated_path = translated_dir / path.name
                 translated_path.write_text(translated_text + "\n", encoding="utf-8")
             except Exception as exc:  # noqa: BLE001
                 failed += 1
-                failures.append(
-                    {"chapter_number": number, "stage": "translate", "error": str(exc)}
-                )
+                failures.append({"chapter_number": number, "stage": "translate", "error": str(exc)})
                 if args.strict:
                     raise
                 continue
@@ -433,7 +429,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--chapter-start", type=int, default=1)
     parser.add_argument("--chapter-end", type=int, default=0)
     parser.add_argument("--max-chapters", type=int, default=0)
-    parser.add_argument("--translate-provider", choices=["none", "argos", "libretranslate", "chain"], default="chain")
+    parser.add_argument(
+        "--translate-provider",
+        choices=["none", "argos", "libretranslate", "chain"],
+        default="chain",
+    )
     parser.add_argument("--source-language", default="ja")
     parser.add_argument("--target-language", default="en")
     parser.add_argument("--libretranslate-url", default="http://localhost:5000")

--- a/src/story_gen/cli/reference_pipeline.py
+++ b/src/story_gen/cli/reference_pipeline.py
@@ -406,6 +406,8 @@ def _chunk_text(text: str, max_chars: int) -> list[str]:
 class LibreTranslateTranslator:
     """Translation adapter for LibreTranslate-compatible APIs."""
 
+    name = "libretranslate.v1"
+
     def __init__(
         self,
         *,

--- a/src/story_gen/cli/reference_pipeline.py
+++ b/src/story_gen/cli/reference_pipeline.py
@@ -520,7 +520,9 @@ def _translate_with_retry(
 def _looks_untranslated(source: str, translated: str) -> bool:
     if not translated.strip():
         return True
-    source_has_jp = sum(1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff")
+    source_has_jp = sum(
+        1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff"
+    )
     if source_has_jp == 0:
         return False
     translated_ascii = sum(1 for ch in translated if "a" <= ch.lower() <= "z")

--- a/src/story_gen/cli/reference_pipeline.py
+++ b/src/story_gen/cli/reference_pipeline.py
@@ -29,6 +29,7 @@ DEFAULT_USER_AGENT = "story_gen_reference_bot/0.1 (respectful crawler; personal 
 DEFAULT_CRAWL_DELAY_SECONDS = 1.1
 DEFAULT_TRANSLATE_DELAY_SECONDS = 0.25
 DEFAULT_TRANSLATE_CHUNK_SIZE = 1200
+DEFAULT_TRANSLATE_MAX_RETRIES = 5
 
 
 @dataclass(frozen=True)
@@ -71,7 +72,7 @@ class PipelineArgs:
     max_episodes: int | None
     crawl_delay_seconds: float
     force_fetch: bool
-    translate_provider: Literal["none", "libretranslate"]
+    translate_provider: Literal["none", "libretranslate", "argos", "chain"]
     source_language: str
     target_language: str
     libretranslate_url: str
@@ -415,6 +416,7 @@ class LibreTranslateTranslator:
         api_key: str | None = None,
         delay_seconds: float = DEFAULT_TRANSLATE_DELAY_SECONDS,
         chunk_size: int = DEFAULT_TRANSLATE_CHUNK_SIZE,
+        max_retries: int = DEFAULT_TRANSLATE_MAX_RETRIES,
     ) -> None:
         self._client = client
         self._endpoint = f"{base_url.rstrip('/')}/translate"
@@ -423,6 +425,7 @@ class LibreTranslateTranslator:
         self._api_key = api_key
         self._delay_seconds = delay_seconds
         self._chunk_size = chunk_size
+        self._max_retries = max_retries
 
     def translate(self, text: str) -> str:
         """Translate text in chunks to avoid request size limits."""
@@ -442,21 +445,131 @@ class LibreTranslateTranslator:
             if self._api_key:
                 payload["api_key"] = self._api_key
 
-            response = self._client.post(self._endpoint, json=payload)
-            response.raise_for_status()
-            raw_data = response.json()
-            if not isinstance(raw_data, dict):
-                raise RuntimeError("LibreTranslate response was not a JSON object.")
-            data: Mapping[str, object] = raw_data
-            translated = data.get("translatedText")
-            if not isinstance(translated, str):
-                raise RuntimeError("LibreTranslate response missing translatedText.")
-            translated_chunks.append(translated.strip())
+            translated_chunks.append(
+                _translate_with_retry(
+                    client=self._client,
+                    endpoint=self._endpoint,
+                    payload=payload,
+                    max_retries=self._max_retries,
+                )
+            )
 
             if index < len(chunks) - 1 and self._delay_seconds > 0:
                 time.sleep(self._delay_seconds)
 
         return "\n\n".join(translated_chunks).strip()
+
+
+class TranslationError(RuntimeError):
+    """Raised when translation fails."""
+
+
+class ArgosTranslateTranslator:
+    """Offline translation adapter for Argos Translate."""
+
+    name = "argos.v1"
+
+    def __init__(self, source_language: str, target_language: str) -> None:
+        try:
+            import argostranslate.translate as argos_translate  # type: ignore
+        except Exception as exc:  # noqa: BLE001
+            raise TranslationError("argostranslate is not installed") from exc
+        languages = argos_translate.get_installed_languages()
+        source = next((lang for lang in languages if lang.code == source_language), None)
+        target = next((lang for lang in languages if lang.code == target_language), None)
+        if source is None or target is None:
+            raise TranslationError(
+                f"argostranslate missing language pair {source_language}->{target_language}"
+            )
+        self._translator = source.get_translation(target)
+
+    def translate(self, text: str) -> str:
+        return self._translator.translate(text)
+
+
+def _translate_with_retry(
+    *,
+    client: httpx.Client,
+    endpoint: str,
+    payload: LibreTranslateRequest,
+    max_retries: int,
+) -> str:
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = client.post(endpoint, json=payload)
+            if response.status_code in {429, 503}:
+                raise TranslationError(f"LibreTranslate throttled: {response.status_code}")
+            response.raise_for_status()
+            raw_data = response.json()
+            if not isinstance(raw_data, dict):
+                raise TranslationError("LibreTranslate response was not a JSON object.")
+            data: Mapping[str, object] = raw_data
+            translated = data.get("translatedText")
+            if not isinstance(translated, str):
+                raise TranslationError("LibreTranslate response missing translatedText.")
+            return translated.strip()
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(min(8.0, 0.6 * attempt))
+    if last_error is not None:
+        raise TranslationError(str(last_error)) from last_error
+    raise TranslationError("LibreTranslate failed without error detail")
+
+
+def _looks_untranslated(source: str, translated: str) -> bool:
+    if not translated.strip():
+        return True
+    source_has_jp = sum(1 for ch in source if "\u3040" <= ch <= "\u30ff" or "\u4e00" <= ch <= "\u9fff")
+    if source_has_jp == 0:
+        return False
+    translated_ascii = sum(1 for ch in translated if "a" <= ch.lower() <= "z")
+    unknown_ratio = translated.count("?") / max(1, len(translated))
+    return translated_ascii < 10 or unknown_ratio > 0.2
+
+
+def _translator_chain(args: PipelineArgs, client: httpx.Client) -> list[object]:
+    if args.translate_provider == "none":
+        return []
+    chain: list[object] = []
+    if args.translate_provider in {"argos", "chain"}:
+        try:
+            chain.append(ArgosTranslateTranslator(args.source_language, args.target_language))
+        except TranslationError:
+            if args.translate_provider == "argos":
+                raise
+    if args.translate_provider in {"libretranslate", "chain"}:
+        chain.append(
+            LibreTranslateTranslator(
+                client=client,
+                base_url=args.libretranslate_url,
+                source_language=args.source_language,
+                target_language=args.target_language,
+                api_key=args.libretranslate_api_key,
+                delay_seconds=args.translate_delay_seconds,
+                chunk_size=args.translate_chunk_size,
+            )
+        )
+    return chain
+
+
+def _translate_text(source_text: str, chain: list[object]) -> tuple[str, str]:
+    if not chain:
+        return source_text, "none"
+    last_error: Exception | None = None
+    for translator in chain:
+        name = getattr(translator, "name", "unknown")
+        try:
+            translated = translator.translate(source_text)
+            if _looks_untranslated(source_text, translated):
+                raise TranslationError(f"{name} produced low-quality output")
+            return translated, name
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            continue
+    if last_error is not None:
+        raise TranslationError(str(last_error)) from last_error
+    raise TranslationError("translation failed")
 
 
 def _load_focus_names(names_argument: str, work_dir: Path) -> list[str]:
@@ -724,49 +837,49 @@ def run_pipeline(args: PipelineArgs) -> None:
             )
 
         translated_map: dict[int, str] = {}
-        if args.translate_provider == "libretranslate":
-            translator = LibreTranslateTranslator(
-                client=client,
-                base_url=args.libretranslate_url,
-                source_language=args.source_language,
-                target_language=args.target_language,
-                api_key=args.libretranslate_api_key,
-                delay_seconds=args.translate_delay_seconds,
-                chunk_size=args.translate_chunk_size,
-            )
-            print(
-                "[translate] using LibreTranslate endpoint "
-                f"{args.libretranslate_url} ({args.source_language}->{args.target_language})"
-            )
-            for idx, episode in enumerate(episode_records, start=1):
-                output_file = translated_dir / f"{episode.episode_number:04d}.json"
-                if output_file.exists() and not args.force_translate:
-                    raw_cached = json.loads(output_file.read_text(encoding="utf-8"))
-                    translated_text = _translated_text_from_loaded(raw_cached)
-                    if translated_text is not None:
-                        translated_map[episode.episode_number] = translated_text
-                        print(
-                            "[translate] "
-                            f"{idx}/{len(episode_records)} episode {episode.episode_number}: cached"
-                        )
-                        continue
+    if args.translate_provider != "none":
+        chain = _translator_chain(args, client)
+        print(
+            "[translate] provider "
+            f"{args.translate_provider} ({args.source_language}->{args.target_language})"
+        )
+        for idx, episode in enumerate(episode_records, start=1):
+            output_file = translated_dir / f"{episode.episode_number:04d}.json"
+            if output_file.exists() and not args.force_translate:
+                raw_cached = json.loads(output_file.read_text(encoding="utf-8"))
+                translated_text = _translated_text_from_loaded(raw_cached)
+                if translated_text is not None:
+                    translated_map[episode.episode_number] = translated_text
+                    print(
+                        "[translate] "
+                        f"{idx}/{len(episode_records)} episode {episode.episode_number}: cached"
+                    )
+                    continue
 
-                translated_text = translator.translate(episode.text_jp)
-                translated_map[episode.episode_number] = translated_text
-                translated_payload: TranslationPayload = {
-                    "episode_number": episode.episode_number,
-                    "source_language": args.source_language,
-                    "target_language": args.target_language,
-                    "text_translated": translated_text,
-                }
-                _write_json(output_file, translated_payload)
+            try:
+                translated_text, provider_name = _translate_text(episode.text_jp, chain)
+            except Exception as exc:  # noqa: BLE001
                 print(
                     "[translate] "
                     f"{idx}/{len(episode_records)} episode {episode.episode_number}: "
-                    f"saved ({len(translated_text)} chars)"
+                    f"failed ({exc})"
                 )
-        else:
-            print("[translate] skipped (provider=none)")
+                continue
+            translated_map[episode.episode_number] = translated_text
+            translated_payload: TranslationPayload = {
+                "episode_number": episode.episode_number,
+                "source_language": args.source_language,
+                "target_language": args.target_language,
+                "text_translated": translated_text,
+            }
+            _write_json(output_file, translated_payload)
+            print(
+                "[translate] "
+                f"{idx}/{len(episode_records)} episode {episode.episode_number}: "
+                f"saved ({len(translated_text)} chars, provider={provider_name})"
+            )
+    else:
+        print("[translate] skipped (provider=none)")
 
     focus_names = _load_focus_names(args.analysis_names, work_dir)
     analysis = build_analysis(episode_records, focus_names)
@@ -805,7 +918,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-episodes", type=int, default=0)
     parser.add_argument("--crawl-delay-seconds", type=float, default=DEFAULT_CRAWL_DELAY_SECONDS)
     parser.add_argument("--force-fetch", action="store_true")
-    parser.add_argument("--translate-provider", choices=["none", "libretranslate"], default="none")
+    parser.add_argument(
+        "--translate-provider",
+        choices=["none", "libretranslate", "argos", "chain"],
+        default="none",
+    )
     parser.add_argument("--source-language", default="ja")
     parser.add_argument("--target-language", default="en")
     parser.add_argument(
@@ -832,9 +949,9 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 def _pipeline_args_from_namespace(namespace: argparse.Namespace) -> PipelineArgs:
     """Convert CLI namespace into fully-normalized pipeline arguments."""
-    translate_provider: Literal["none", "libretranslate"]
-    if namespace.translate_provider == "libretranslate":
-        translate_provider = "libretranslate"
+    translate_provider: Literal["none", "libretranslate", "argos", "chain"]
+    if namespace.translate_provider in {"libretranslate", "argos", "chain"}:
+        translate_provider = namespace.translate_provider
     else:
         translate_provider = "none"
 

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -4,9 +4,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-from fastapi.testclient import TestClient
 import jwt
 from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.testclient import TestClient
 
 import story_gen.api.app as app_module
 from story_gen.adapters.sqlite_anomaly_store import SQLiteAnomalyStore
@@ -89,7 +89,9 @@ def _auth_headers(client: TestClient, email: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _oidc_token_and_jwks(*, issuer: str, audience: str, subject: str, email: str) -> tuple[str, dict[str, Any]]:
+def _oidc_token_and_jwks(
+    *, issuer: str, audience: str, subject: str, email: str
+) -> tuple[str, dict[str, Any]]:
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     public_key = key.public_key()
     jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(public_key))

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from fastapi.testclient import TestClient
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 import story_gen.api.app as app_module
 from story_gen.adapters.sqlite_anomaly_store import SQLiteAnomalyStore
@@ -85,6 +87,27 @@ def _auth_headers(client: TestClient, email: str) -> dict[str, str]:
     assert login.status_code == 200
     token = login.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
+
+
+def _oidc_token_and_jwks(*, issuer: str, audience: str, subject: str, email: str) -> tuple[str, dict[str, Any]]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = key.public_key()
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(public_key))
+    jwk["kid"] = "test-kid"
+    token = jwt.encode(
+        {
+            "iss": issuer,
+            "aud": audience,
+            "sub": subject,
+            "email": email,
+            "preferred_username": "oidc-user",
+            "name": "OIDC User",
+        },
+        key,
+        algorithm="RS256",
+        headers={"kid": "test-kid"},
+    )
+    return token, {"keys": [jwk]}
 
 
 def test_health_endpoint_returns_ok_payload() -> None:
@@ -945,3 +968,62 @@ def test_dashboard_heatmap_export_rejects_unknown_stage_value(tmp_path: Path) ->
     payload_errors = [event for event in anomalies if event.code == "invalid_payload_shape"]
     assert payload_errors
     assert any('"value": "epilogue"' in event.metadata_json for event in payload_errors)
+
+
+def test_keycloak_mode_accepts_oidc_token_for_me(tmp_path: Path, monkeypatch: Any) -> None:
+    issuer = "https://id.example.test/realms/story"
+    audience = "story_gen_api"
+    token, jwks = _oidc_token_and_jwks(
+        issuer=issuer,
+        audience=audience,
+        subject="user-oidc-1",
+        email="oidc@example.com",
+    )
+    monkeypatch.setenv("STORY_GEN_AUTH_MODE", "keycloak")
+    monkeypatch.setenv("STORY_GEN_OIDC_ISSUER", issuer)
+    monkeypatch.setenv("STORY_GEN_OIDC_AUDIENCE", audience)
+    monkeypatch.setenv("STORY_GEN_OIDC_JWKS_JSON", json.dumps(jwks))
+
+    client = TestClient(create_app(db_path=tmp_path / "stories.db"))
+    response = client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["email"] == "oidc@example.com"
+    assert payload["display_name"] == "oidc-user"
+
+
+def test_keycloak_mode_rejects_local_register_and_login(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setenv("STORY_GEN_AUTH_MODE", "keycloak")
+    monkeypatch.setenv("STORY_GEN_OIDC_ISSUER", "https://id.example.test/realms/story")
+    monkeypatch.setenv("STORY_GEN_OIDC_JWKS_JSON", json.dumps({"keys": []}))
+    client = TestClient(create_app(db_path=tmp_path / "stories.db"))
+
+    register = client.post(
+        "/api/v1/auth/register",
+        json={"email": "alice@example.com", "password": "password123", "display_name": "Alice"},
+    )
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": "alice@example.com", "password": "password123"},
+    )
+    assert register.status_code == 501
+    assert login.status_code == 501
+
+
+def test_keycloak_mode_rejects_invalid_token(tmp_path: Path, monkeypatch: Any) -> None:
+    issuer = "https://id.example.test/realms/story"
+    audience = "story_gen_api"
+    token, jwks = _oidc_token_and_jwks(
+        issuer=issuer,
+        audience=audience,
+        subject="user-oidc-2",
+        email="oidc2@example.com",
+    )
+    monkeypatch.setenv("STORY_GEN_AUTH_MODE", "keycloak")
+    monkeypatch.setenv("STORY_GEN_OIDC_ISSUER", issuer)
+    monkeypatch.setenv("STORY_GEN_OIDC_AUDIENCE", audience)
+    monkeypatch.setenv("STORY_GEN_OIDC_JWKS_JSON", json.dumps(jwks))
+
+    client = TestClient(create_app(db_path=tmp_path / "stories.db"))
+    bad = client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}x"})
+    assert bad.status_code == 401

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -63,9 +63,7 @@ def test_reference_main_builds_pipeline_args(monkeypatch: pytest.MonkeyPatch) ->
     assert seen[0].project_id == "n2267be"
 
 
-def test_pipeline_batch_main_builds_args(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_pipeline_batch_main_builds_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[object] = []
 
     def fake_run(args: object) -> None:

--- a/tests/test_cli_entrypoints.py
+++ b/tests/test_cli_entrypoints.py
@@ -16,6 +16,7 @@ from story_gen.cli import (
     blueprint,
     dashboard_export,
     features,
+    pipeline_batch,
     pipeline_canary,
     qa_evaluation,
     reference_pipeline,
@@ -60,6 +61,20 @@ def test_reference_main_builds_pipeline_args(monkeypatch: pytest.MonkeyPatch) ->
     reference_pipeline.main(["--project-id", "n2267be", "--max-episodes", "1"])
     assert seen
     assert seen[0].project_id == "n2267be"
+
+
+def test_pipeline_batch_main_builds_args(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[object] = []
+
+    def fake_run(args: object) -> None:
+        seen.append(args)
+
+    monkeypatch.setattr("story_gen.cli.pipeline_batch.run_pipeline_batch", fake_run)
+    pipeline_batch.main(["--source-dir", str(tmp_path), "--run-id", "batch-test"])
+    assert seen
+    assert getattr(seen[0], "run_id") == "batch-test"
 
 
 def test_video_main_builds_video_story_args(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_pipeline_batch.py
+++ b/tests/test_pipeline_batch.py
@@ -36,8 +36,9 @@ def test_pipeline_batch_analyzes_chapters_and_writes_summary(tmp_path: Path) -> 
     summary = run_pipeline_batch(args)
     assert summary.processed_chapters == 2
     assert summary.failed_chapters == 0
-    assert summary.elapsed_seconds > 0
+    assert summary.elapsed_seconds >= 0
     assert summary.timing_totals
+    assert summary.timing_totals["total_seconds"] > 0
 
     summary_path = output_dir / "test-run" / "summary.json"
     payload = json.loads(summary_path.read_text(encoding="utf-8"))

--- a/tests/test_pipeline_batch.py
+++ b/tests/test_pipeline_batch.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from story_gen.cli.pipeline_batch import build_arg_parser, run_pipeline_batch
+
+
+def _write_chapter(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def test_pipeline_batch_analyzes_chapters_and_writes_summary(tmp_path: Path) -> None:
+    source_dir = tmp_path / "chapters"
+    source_dir.mkdir()
+    _write_chapter(source_dir / "0001.txt", "Rhea found the ledger and confronted the council.")
+    _write_chapter(source_dir / "0002.txt", "The city accepted the truth and began to heal.")
+
+    output_dir = tmp_path / "runs"
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        [
+            "--source-dir",
+            str(source_dir),
+            "--output-dir",
+            str(output_dir),
+            "--run-id",
+            "test-run",
+            "--translate-provider",
+            "none",
+            "--mode",
+            "analyze",
+        ]
+    )
+
+    summary = run_pipeline_batch(args)
+    assert summary.processed_chapters == 2
+    assert summary.failed_chapters == 0
+    assert summary.elapsed_seconds > 0
+    assert summary.timing_totals
+
+    summary_path = output_dir / "test-run" / "summary.json"
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert payload["processed_chapters"] == 2
+    assert payload["failed_chapters"] == 0
+    assert payload["timing_totals"]
+
+    chapter_summary = output_dir / "test-run" / "chapters" / "0001.json"
+    assert chapter_summary.exists()

--- a/tests/test_project_contracts.py
+++ b/tests/test_project_contracts.py
@@ -37,6 +37,7 @@ def test_makefile_contains_quality_and_native_targets() -> None:
     assert "collect-story:" in makefile
     assert "video-story:" in makefile
     assert "pipeline-canary:" in makefile
+    assert "pipeline-batch:" in makefile
     assert "qa-eval:" in makefile
     assert "features:" in makefile
     assert "dev-stack-hot:" in makefile
@@ -219,6 +220,7 @@ def test_pyproject_exposes_story_collection_entrypoints() -> None:
     assert 'story-dashboard-export = "story_gen.cli.dashboard_export:main"' in pyproject
     assert 'story-pipeline-canary = "story_gen.cli.pipeline_canary:main"' in pyproject
     assert 'story-qa-eval = "story_gen.cli.qa_evaluation:main"' in pyproject
+    assert 'story-pipeline-batch = "story_gen.cli.pipeline_batch:main"' in pyproject
 
 
 def test_mkdocs_configuration_exists() -> None:
@@ -238,6 +240,7 @@ def test_mkdocs_configuration_exists() -> None:
     assert "Droplet Stack:" in config
     assert "Feature Pipeline:" in config
     assert "QA Evaluation:" in config
+    assert "Lessons Learned (Re:Zero E2E):" in config
     assert "Story Bundle:" in config
     assert "Graph Strategy:" in config
     assert "Architecture:" in config
@@ -263,6 +266,8 @@ def test_mkdocs_configuration_exists() -> None:
     assert "0028 QA Evaluation Harness and Calibration Gates:" in config
     assert "0029 NLP Provider Resilience and Insight Calibration:" in config
     assert "0030 OpenAPI Snapshot and Hosted API Reference:" in config
+    assert "0031 Keycloak OIDC Auth:" in config
+    assert "0032 Batch Pipeline Re:Zero Benchmark:" in config
     assert "pymdownx.superfences" in config
     assert "mermaid.min.js" in config
     assert "javascripts/mermaid.js" in config
@@ -382,6 +387,8 @@ def test_architecture_docs_and_adr_scaffold_exist() -> None:
         ROOT / "docs" / "adr" / "0029-nlp-provider-resilience-and-insight-calibration.md"
     ).exists()
     assert (ROOT / "docs" / "adr" / "0030-openapi-snapshot-and-hosted-api-reference.md").exists()
+    assert (ROOT / "docs" / "adr" / "0031-keycloak-oidc-auth.md").exists()
+    assert (ROOT / "docs" / "adr" / "0032-batch-pipeline-re-zero-benchmark.md").exists()
     assert (ROOT / "docs" / "story_bundle.md").exists()
     assert (ROOT / "docs" / "observability.md").exists()
     assert (ROOT / "docs" / "graph_strategy.md").exists()

--- a/tests/test_reference_pipeline.py
+++ b/tests/test_reference_pipeline.py
@@ -110,6 +110,7 @@ class _FakeResponse:
     def __init__(self, *, text: str = "", json_payload: object = None) -> None:
         self.text = text
         self._json_payload = {} if json_payload is None else json_payload
+        self.status_code = 200
 
     def raise_for_status(self) -> None:
         return None

--- a/tests/test_story_analysis_pipeline.py
+++ b/tests/test_story_analysis_pipeline.py
@@ -68,11 +68,15 @@ def test_pipeline_reports_stage_timings() -> None:
         "total_seconds",
     }
     assert expected_keys.issubset(result.timing.keys())
-    assert result.timing["total_seconds"] >= sum(
-        result.timing[key]
-        for key in expected_keys
-        if key.endswith("_seconds") and key != "total_seconds"
-    ) * 0.5
+    assert (
+        result.timing["total_seconds"]
+        >= sum(
+            result.timing[key]
+            for key in expected_keys
+            if key.endswith("_seconds") and key != "total_seconds"
+        )
+        * 0.5
+    )
 
 
 def test_pipeline_generates_macro_meso_micro_insights() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -45,6 +45,24 @@ wheels = [
 ]
 
 [[package]]
+name = "argostranslate"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ctranslate2" },
+    { name = "minisbd" },
+    { name = "packaging" },
+    { name = "sacremoses" },
+    { name = "sentencepiece" },
+    { name = "spacy" },
+    { name = "stanza" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/0c/2887de7e72805eb37dac37cdd84132691c95b5842463b634bf86000d259a/argostranslate-1.11.0.tar.gz", hash = "sha256:be43fa826cbac15399a33a90c842dfe504ad6b8fa55e252514e7071f5425b406", size = 39275, upload-time = "2026-02-02T13:23:02.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/16/aa4ddcbc3a3fe352ca3046ef90e612147e0604cbc84a2a70e48df4021bb9/argostranslate-1.11.0-py3-none-any.whl", hash = "sha256:a89b42d82f40843900338f9ac60d4c82fda590b6898247f5d0c15d46731ca7df", size = 41551, upload-time = "2026-02-02T13:23:01.631Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +173,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -400,6 +488,102 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/99/157aae7949a5f30d51fcb1a9851e8ebd5c74bf99b5285d8bb4b8b9ee641e/cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485", size = 7173686, upload-time = "2026-01-28T00:23:07.515Z" },
+    { url = "https://files.pythonhosted.org/packages/87/91/874b8910903159043b5c6a123b7e79c4559ddd1896e38967567942635778/cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc", size = 4275871, upload-time = "2026-01-28T00:23:09.439Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/35/690e809be77896111f5b195ede56e4b4ed0435b428c2f2b6d35046fbb5e8/cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0", size = 4423124, upload-time = "2026-01-28T00:23:11.529Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/5b/a26407d4f79d61ca4bebaa9213feafdd8806dc69d3d290ce24996d3cfe43/cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa", size = 4277090, upload-time = "2026-01-28T00:23:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d8/4bb7aec442a9049827aa34cee1aa83803e528fa55da9a9d45d01d1bb933e/cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81", size = 4947652, upload-time = "2026-01-28T00:23:14.554Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/08/f83e2e0814248b844265802d081f2fac2f1cbe6cd258e72ba14ff006823a/cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255", size = 4455157, upload-time = "2026-01-28T00:23:16.443Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/05/19d849cf4096448779d2dcc9bb27d097457dac36f7273ffa875a93b5884c/cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e", size = 3981078, upload-time = "2026-01-28T00:23:17.838Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/89/f7bac81d66ba7cde867a743ea5b37537b32b5c633c473002b26a226f703f/cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c", size = 4276213, upload-time = "2026-01-28T00:23:19.257Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9f/7133e41f24edd827020ad21b068736e792bc68eecf66d93c924ad4719fb3/cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32", size = 4912190, upload-time = "2026-01-28T00:23:21.244Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/6d43cbaddf6f65b24816e4af187d211f0bc536a29961f69faedc48501d8e/cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616", size = 4454641, upload-time = "2026-01-28T00:23:22.866Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4f/ebd0473ad656a0ac912a16bd07db0f5d85184924e14fc88feecae2492834/cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0", size = 4405159, upload-time = "2026-01-28T00:23:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f7/7923886f32dc47e27adeff8246e976d77258fd2aa3efdd1754e4e323bf49/cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0", size = 4666059, upload-time = "2026-01-28T00:23:26.766Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a7/0fca0fd3591dffc297278a61813d7f661a14243dd60f499a7a5b48acb52a/cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5", size = 3026378, upload-time = "2026-01-28T00:23:28.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/12/652c84b6f9873f0909374864a57b003686c642ea48c84d6c7e2c515e6da5/cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b", size = 3478614, upload-time = "2026-01-28T00:23:30.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/27/542b029f293a5cce59349d799d4d8484b3b1654a7b9a0585c266e974a488/cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908", size = 7116417, upload-time = "2026-01-28T00:23:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f5/559c25b77f40b6bf828eabaf988efb8b0e17b573545edb503368ca0a2a03/cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da", size = 4264508, upload-time = "2026-01-28T00:23:34.264Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a1/551fa162d33074b660dc35c9bc3616fefa21a0e8c1edd27b92559902e408/cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829", size = 4409080, upload-time = "2026-01-28T00:23:35.793Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/4d8d129a755f5d6df1bbee69ea2f35ebfa954fa1847690d1db2e8bca46a5/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2", size = 4270039, upload-time = "2026-01-28T00:23:37.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f5/ed3fcddd0a5e39321e595e144615399e47e7c153a1fb8c4862aec3151ff9/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085", size = 4926748, upload-time = "2026-01-28T00:23:38.884Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ae/9f03d5f0c0c00e85ecb34f06d3b79599f20630e4db91b8a6e56e8f83d410/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b", size = 4442307, upload-time = "2026-01-28T00:23:40.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/22/e0f9f2dae8040695103369cf2283ef9ac8abe4d51f68710bec2afd232609/cryptography-46.0.4-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd", size = 3959253, upload-time = "2026-01-28T00:23:42.827Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5b/6a43fcccc51dae4d101ac7d378a8724d1ba3de628a24e11bf2f4f43cba4d/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2", size = 4269372, upload-time = "2026-01-28T00:23:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b7/0f6b8c1dd0779df2b526e78978ff00462355e31c0a6f6cff8a3e99889c90/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e", size = 4891908, upload-time = "2026-01-28T00:23:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/17/259409b8349aa10535358807a472c6a695cf84f106022268d31cea2b6c97/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f", size = 4441254, upload-time = "2026-01-28T00:23:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fe/e4a1b0c989b00cee5ffa0764401767e2d1cf59f45530963b894129fd5dce/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82", size = 4396520, upload-time = "2026-01-28T00:23:50.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/ba8fd9657d27076eb40d6a2f941b23429a3c3d2f56f5a921d6b936a27bc9/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c", size = 4651479, upload-time = "2026-01-28T00:23:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/00/03/0de4ed43c71c31e4fe954edd50b9d28d658fef56555eba7641696370a8e2/cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061", size = 3001986, upload-time = "2026-01-28T00:23:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/70/81830b59df7682917d7a10f833c4dab2a5574cd664e86d18139f2b421329/cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7", size = 3468288, upload-time = "2026-01-28T00:23:55.09Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f7/f648fdbb61d0d45902d3f374217451385edc7e7768d1b03ff1d0e5ffc17b/cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab", size = 7169583, upload-time = "2026-01-28T00:23:56.558Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cc/8f3224cbb2a928de7298d6ed4790f5ebc48114e02bdc9559196bfb12435d/cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef", size = 4275419, upload-time = "2026-01-28T00:23:58.364Z" },
+    { url = "https://files.pythonhosted.org/packages/17/43/4a18faa7a872d00e4264855134ba82d23546c850a70ff209e04ee200e76f/cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d", size = 4419058, upload-time = "2026-01-28T00:23:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/64/6651969409821d791ba12346a124f55e1b76f66a819254ae840a965d4b9c/cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973", size = 4278151, upload-time = "2026-01-28T00:24:01.731Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0b/a7fce65ee08c3c02f7a8310cc090a732344066b990ac63a9dfd0a655d321/cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4", size = 4939441, upload-time = "2026-01-28T00:24:03.175Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/20c5701e2cd3e1dfd7a19d2290c522a5f435dd30957d431dcb531d0f1413/cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af", size = 4451617, upload-time = "2026-01-28T00:24:05.403Z" },
+    { url = "https://files.pythonhosted.org/packages/00/dc/3e16030ea9aa47b63af6524c354933b4fb0e352257c792c4deeb0edae367/cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263", size = 3977774, upload-time = "2026-01-28T00:24:06.851Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c8/ad93f14118252717b465880368721c963975ac4b941b7ef88f3c56bf2897/cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095", size = 4277008, upload-time = "2026-01-28T00:24:08.926Z" },
+    { url = "https://files.pythonhosted.org/packages/00/cf/89c99698151c00a4631fbfcfcf459d308213ac29e321b0ff44ceeeac82f1/cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b", size = 4903339, upload-time = "2026-01-28T00:24:12.009Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c3/c90a2cb358de4ac9309b26acf49b2a100957e1ff5cc1e98e6c4996576710/cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019", size = 4451216, upload-time = "2026-01-28T00:24:13.975Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2c/8d7f4171388a10208671e181ca43cdc0e596d8259ebacbbcfbd16de593da/cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4", size = 4404299, upload-time = "2026-01-28T00:24:16.169Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/cbb2036e450980f65c6e0a173b73a56ff3bccd8998965dea5cc9ddd424a5/cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b", size = 4664837, upload-time = "2026-01-28T00:24:17.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/21/f7433d18fe6d5845329cbdc597e30caf983229c7a245bcf54afecc555938/cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc", size = 3009779, upload-time = "2026-01-28T00:24:20.198Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/6a/bd2e7caa2facffedf172a45c1a02e551e6d7d4828658c9a245516a598d94/cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976", size = 3466633, upload-time = "2026-01-28T00:24:21.851Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e0/f9c6c53e1f2a1c2507f00f2faba00f01d2f334b35b0fbfe5286715da2184/cryptography-46.0.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b", size = 3476316, upload-time = "2026-01-28T00:24:24.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7a/f8d2d13227a9a1a9fe9c7442b057efecffa41f1e3c51d8622f26b9edbe8f/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da", size = 4216693, upload-time = "2026-01-28T00:24:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/de/3787054e8f7972658370198753835d9d680f6cd4a39df9f877b57f0dd69c/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80", size = 4382765, upload-time = "2026-01-28T00:24:27.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/60e0afb019973ba6a0b322e86b3d61edf487a4f5597618a430a2a15f2d22/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822", size = 4216066, upload-time = "2026-01-28T00:24:29.056Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8e/bf4a0de294f147fee66f879d9bae6f8e8d61515558e3d12785dd90eca0be/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947", size = 4382025, upload-time = "2026-01-28T00:24:30.681Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f4/9ceb90cfd6a3847069b0b0b353fd3075dc69b49defc70182d8af0c4ca390/cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3", size = 3406043, upload-time = "2026-01-28T00:24:32.236Z" },
+]
+
+[[package]]
+name = "ctranslate2"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/25/41920ccee68e91cb6fa0fc9e8078ab2b7839f2c668f750dc123144cb7c6e/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f74200bab9996b14a57cf6f7cb27d0921ceedc4acc1e905598e3e85b4d75b1ec", size = 1256943, upload-time = "2026-02-04T06:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/79/22/bc81fcc9f10ba4da3ffd1a9adec15cfb73cb700b3bbe69c6c8b55d333316/ctranslate2-4.7.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:59b427eb3ac999a746315b03a63942fddd351f511db82ba1a66880d4dea98e25", size = 11916445, upload-time = "2026-02-04T06:11:19.938Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a7/494a66bb02c7926331cadfff51d5ce81f5abfb1e8d05d7f2459082f31b48/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95f0c1051c180669d2a83a44b44b518b2d1683de125f623bbc81ad5dd6f6141c", size = 16696997, upload-time = "2026-02-04T06:11:22.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4e/b48f79fd36e5d3c7e12db383aa49814c340921a618ef7364bd0ced670644/ctranslate2-4.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ed92d9ab0ac6bc7005942be83d68714c80adb0897ab17f98157294ee0374347", size = 38836379, upload-time = "2026-02-04T06:11:26.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/8c01ac52e1f26fc4dbe985a35222ae7cd365bbf7ee5db5fd5545d8926f91/ctranslate2-4.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:67d9ad9b69933fbfeee7dcec899b2cd9341d5dca4fdfb53e8ba8c109dc332ee1", size = 18843315, upload-time = "2026-02-04T06:11:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0f/581de94b64c5f2327a736270bc7e7a5f8fe5cf1ed56a2203b52de4d8986a/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c0cbd46a23b8dc37ccdbd9b447cb5f7fadc361c90e9df17d82ca84b1f019986", size = 1257089, upload-time = "2026-02-04T06:11:32.442Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e9/d55b0e436362f9fe26bd98fefd2dd5d81926121f1d7f799c805e6035bb26/ctranslate2-4.7.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:5b141ddad1da5f84cf3c2a569a56227a37de649a555d376cbd9b80e8f0373dd8", size = 11918502, upload-time = "2026-02-04T06:11:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ce/9f29f0b0bb4280c2ebafb3ddb6cdff8ef1c2e185ee020c0ec0ecba7dc934/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d00a62544db4a3caaa58a3c50d39b25613c042b430053ae32384d94eb1d40990", size = 16859601, upload-time = "2026-02-04T06:11:36.227Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/86/428d270fd72117d19fb48ed3211aa8a3c8bd7577373252962cb634e0fd01/ctranslate2-4.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:722b93a89647974cbd182b4c7f87fefc7794fff7fc9cbd0303b6447905cc157e", size = 38995338, upload-time = "2026-02-04T06:11:42.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f4/d23dbfb9c62cb642c114a30f05d753ba61d6ffbfd8a3a4012fe85a073bcb/ctranslate2-4.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d0f734dc3757118094663bdaaf713f5090c55c1927fb330a76bb8b84173940e8", size = 18844949, upload-time = "2026-02-04T06:11:45.436Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6d/eb49ba05db286b4ea9d5d3fcf5f5cd0a9a5e218d46349618d5041001e303/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6b2abf2929756e3ec6246057b56df379995661560a2d776af05f9d97f63afcf5", size = 1256960, upload-time = "2026-02-04T06:11:47.487Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5a/b9cce7b00d89fc6fdeaf27587aa52d0597b465058563e93ff50910553bdd/ctranslate2-4.7.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:857ef3959d6b1c40dc227c715a36db33db2d097164996d6c75b6db8e30828f52", size = 11918645, upload-time = "2026-02-04T06:11:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/03/c0db0a5276599fb44ceafa2f2cb1afd5628808ec406fe036060a39693680/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:393a9e7e989034660526a2c0e8bb65d1924f43d9a5c77d336494a353d16ba2a4", size = 16860452, upload-time = "2026-02-04T06:11:52.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/03/4e3728ce29d192ee75ed9a2d8589bf4f19edafe5bed3845187de51b179a3/ctranslate2-4.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a3d0682f2b9082e31c73d75b45f16cde77355ab76d7e8356a24c3cb2480a6d3", size = 38995174, upload-time = "2026-02-04T06:11:55.477Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/15/6e8e87c6a201d69803a79ac2e29623ce7c2cc9cd1df9db99810cca714373/ctranslate2-4.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:baa6d2b10f57933d8c11791e8522659217918722d07bbef2389a443801125fe7", size = 18844953, upload-time = "2026-02-04T06:11:58.519Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/8a6b7ba18cad0c8667ee221ddab8c361cb70926440e5b8dd0e81924c28ac/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d5dfb076566551f4959dfd0706f94c923c1931def9b7bb249a2caa6ab23353a0", size = 1257560, upload-time = "2026-02-04T06:12:00.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c2/8817ca5d6c1b175b23a12f7c8b91484652f8718a76353317e5919b038733/ctranslate2-4.7.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:eecdb4ed934b384f16e8c01b185b082d6b5ffc7dcbb0b6a6eb48cd465282d957", size = 11918995, upload-time = "2026-02-04T06:12:02.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/b8eb3acc67bbca4d9872fc9ff94db78e6167a7ba5cd932f585d1560effc7/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1aa6796edcc3c8d163c9e39c429d50076d266d68980fed9d1b2443f617c67e9e", size = 16844162, upload-time = "2026-02-04T06:12:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/80/11/6474893b07121057035069a0a483fe1cd8c47878213f282afb4c0c6fc275/ctranslate2-4.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24c0482c51726430fb83724451921c0e539d769c8618dcfd46b1645e7f75960d", size = 38966728, upload-time = "2026-02-04T06:12:07.923Z" },
+    { url = "https://files.pythonhosted.org/packages/94/88/8fc7ff435c5e783e5fad9586d839d463e023988dbbbad949d442092d01f1/ctranslate2-4.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:76db234c0446a23d20dd8eeaa7a789cc87d1d05283f48bf3152bae9fa0a69844", size = 19100788, upload-time = "2026-02-04T06:12:10.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/f100013a76a98d64e67c721bd4559ea4eeb54be3e4ac45f4d801769899af/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:058c9db2277dc8b19ecc86c7937628f69022f341844b9081d2ab642965d88fc6", size = 1280179, upload-time = "2026-02-04T06:12:12.596Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/b77f748015667a5e2ca54a5ee080d7016fce34314f0e8cf904784549305a/ctranslate2-4.7.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:5abcf885062c7f28a3f9a46be8d185795e8706ac6230ad086cae0bc82917df31", size = 11940166, upload-time = "2026-02-04T06:12:14.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/78/6d7fd52f646c6ba3343f71277a9bbef33734632949d1651231948b0f0359/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9950acb04a002d5c60ae90a1ddceead1a803af1f00cadd9b1a1dc76e1f017481", size = 16849483, upload-time = "2026-02-04T06:12:17.082Z" },
+    { url = "https://files.pythonhosted.org/packages/40/27/58769ff15ac31b44205bd7a8aeca80cf7357c657ea5df1b94ce0f5c83771/ctranslate2-4.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1dcc734e92e3f1ceeaa0c42bbfd009352857be179ecd4a7ed6cccc086a202f58", size = 38949393, upload-time = "2026-02-04T06:12:21.302Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5c/9fa0ad6462b62efd0fb5ac1100eee47bc96ecc198ff4e237c731e5473616/ctranslate2-4.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dfb7657bdb7b8211c8f9ecb6f3b70bc0db0e0384d01a8b1808cb66fe7199df59", size = 19123451, upload-time = "2026-02-04T06:12:24.115Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +704,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -884,6 +1076,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "minisbd"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/c5/388b9cf14891925a8bb02968c6c689ad09dea0ca4800bd09ce204fb4847d/minisbd-0.9.3.tar.gz", hash = "sha256:7f35f489fb64a63b121f06fbda8b5e0e2a982b0d111c926daaabbec3e535ab19", size = 39396, upload-time = "2026-01-26T22:01:55.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/3d/143f06e7a0f35d69583b6177ba71d3faef4a6a0db6be7ebafa15c27133e1/minisbd-0.9.3-py3-none-any.whl", hash = "sha256:e1eeef3126263663b29971a88fc9f5e93a2de46619ff56b1b7b7ac9c42dc90ee", size = 40877, upload-time = "2026-01-26T22:01:53.985Z" },
 ]
 
 [[package]]
@@ -1339,6 +1545,40 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/88/d9757c62a0f96b5193f8d447a141eefd14498c404cc5caf1a6f3233cf102/onnxruntime-1.24.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:79b3119ab9f4f3817062e6dbe7f4a44937de93905e3a31ba34313d18cb49e7be", size = 17212018, upload-time = "2026-02-05T17:32:13.986Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/b3305c39144e19dbe8791802076b29b4b592b09de03d0e340c1314bfd408/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:86bc43e922b1f581b3de26a3dc402149c70e5542fceb5bec6b3a85542dbeb164", size = 15018703, upload-time = "2026-02-05T17:30:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d6/d273b75fe7825ea3feed321dd540aef33d8a1380ddd8ac3bb70a8ed000fe/onnxruntime-1.24.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cabe71ca14dcfbf812d312aab0a704507ac909c137ee6e89e4908755d0fc60e", size = 17096352, upload-time = "2026-02-05T17:31:29.057Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/0616101a3938bfe2918ea60b581a9bbba61ffc255c63388abb0885f7ce18/onnxruntime-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:3273c330f5802b64b4103e87b5bbc334c0355fff1b8935d8910b0004ce2f20c8", size = 12493235, upload-time = "2026-02-05T17:32:04.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/30/437de870e4e1c6d237a2ca5e11f54153531270cb5c745c475d6e3d5c5dcf/onnxruntime-1.24.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7307aab9e2e879c0171f37e0eb2808a5b4aec7ba899bb17c5f0cedfc301a8ac2", size = 17211043, upload-time = "2026-02-05T17:32:16.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/60/004401cd86525101ad8aa9eec301327426555d7a77fac89fd991c3c7aae6/onnxruntime-1.24.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:780add442ce2d4175fafb6f3102cdc94243acffa3ab16eacc03dd627cc7b1b54", size = 15016224, upload-time = "2026-02-05T17:30:56.791Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a1/43ad01b806a1821d1d6f98725edffcdbad54856775643718e9124a09bfbe/onnxruntime-1.24.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6119526eda12613f0d0498e2ae59563c247c370c9cef74c2fc93133dde157", size = 17098191, upload-time = "2026-02-05T17:31:31.87Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/5beb65270864037d5c8fb25cfe6b23c48b618d1f4d06022d425cbf29bd9c/onnxruntime-1.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:df0af2f1cfcfff9094971c7eb1d1dfae7ccf81af197493c4dc4643e4342c0946", size = 12493108, upload-time = "2026-02-05T17:32:07.076Z" },
+    { url = "https://files.pythonhosted.org/packages/95/77/7172ecfcbdabd92f338e694f38c325f6fab29a38fa0a8c3d1c85b9f4617c/onnxruntime-1.24.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:82e367770e8fba8a87ba9f4c04bb527e6d4d7204540f1390f202c27a3b759fb4", size = 17211381, upload-time = "2026-02-05T17:31:09.601Z" },
+    { url = "https://files.pythonhosted.org/packages/79/5b/532a0d75b93bbd0da0e108b986097ebe164b84fbecfdf2ddbf7c8a3a2e83/onnxruntime-1.24.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1099f3629832580fedf415cfce2462a56cc9ca2b560d6300c24558e2ac049134", size = 15016000, upload-time = "2026-02-05T17:31:00.116Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b5/40606c7bce0702975a077bc6668cd072cd77695fc5c0b3fcf59bdb1fe65e/onnxruntime-1.24.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6361dda4270f3939a625670bd67ae0982a49b7f923207450e28433abc9c3a83b", size = 17097637, upload-time = "2026-02-05T17:31:34.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/9e8f7933796b466241b934585723c700d8fb6bde2de856e65335193d7c93/onnxruntime-1.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:bd1e4aefe73b6b99aa303cd72562ab6de3cccb09088100f8ad1c974be13079c7", size = 12492467, upload-time = "2026-02-05T17:32:09.834Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8a/ee07d86e35035f9fed42497af76435f5a613d4e8b6c537ea0f8ef9fa85da/onnxruntime-1.24.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88a2b54dca00c90fca6303eedf13d49b5b4191d031372c2e85f5cffe4d86b79e", size = 15025407, upload-time = "2026-02-05T17:31:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9e/ab3e1dda4b126313d240e1aaa87792ddb1f5ba6d03ca2f093a7c4af8c323/onnxruntime-1.24.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2dfbba602da840615ed5b431facda4b3a43b5d8276cf9e0dbf13d842df105838", size = 17099810, upload-time = "2026-02-05T17:31:37.537Z" },
+    { url = "https://files.pythonhosted.org/packages/87/23/167d964414cee2af9c72af323b28d2c4cb35beed855c830a23f198265c79/onnxruntime-1.24.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:890c503ca187bc883c3aa72c53f2a604ec8e8444bdd1bf6ac243ec6d5e085202", size = 17214004, upload-time = "2026-02-05T17:31:11.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/6e5558fdd51027d6830cf411bc003ae12c64054826382e2fab89e99486a0/onnxruntime-1.24.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da1b84b3bdeec543120df169e5e62a1445bf732fc2c7fb036c2f8a4090455e8", size = 15017034, upload-time = "2026-02-05T17:31:04.331Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d4/3cb1c9eaae1103265ed7eb00a3eaeb0d9ba51dc88edc398b7071c9553bed/onnxruntime-1.24.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:557753ec345efa227c6a65139f3d29c76330fcbd54cc10dd1b64232ebb939c13", size = 17097531, upload-time = "2026-02-05T17:31:40.303Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/4522b199c12db7c5b46aaf265ee0d741abe65ea912f6c0aaa2cc18a4654d/onnxruntime-1.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:ea4942104805e868f3ddddfa1fbb58b04503a534d489ab2d1452bbfa345c78c2", size = 12795556, upload-time = "2026-02-05T17:32:11.886Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/53/3b8969417276b061ff04502ccdca9db4652d397abbeb06c9f6ae05cec9ca/onnxruntime-1.24.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ea8963a99e0f10489acdf00ef3383c3232b7e44aa497b063c63be140530d9f85", size = 15025434, upload-time = "2026-02-05T17:31:06.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a2/cfcf009eb38d90cc628c087b6506b3dfe1263387f3cbbf8d272af4fef957/onnxruntime-1.24.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34488aa760fb5c2e6d06a7ca9241124eb914a6a06f70936a14c669d1b3df9598", size = 17099815, upload-time = "2026-02-05T17:31:43.092Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1555,6 +1795,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1673,6 +1922,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
 ]
 
 [[package]]
@@ -1958,6 +2216,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sacremoses"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/51/fbdc4af4f6e85d26169e28be3763fe50ddfd0d4bf8b871422b0788dcc4d2/sacremoses-0.1.1.tar.gz", hash = "sha256:b6fd5d3a766b02154ed80b962ddca91e1fd25629c0978c7efba21ebccf663934", size = 883188, upload-time = "2023-10-30T15:56:20.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f0/89ee2bc9da434bd78464f288fdb346bc2932f2ee80a90b2a4bbbac262c74/sacremoses-0.1.1-py3-none-any.whl", hash = "sha256:31e04c98b169bfd902144824d191825cd69220cdb4ae4bcf1ec58a7db5587b1a", size = 897476, upload-time = "2023-10-30T15:56:18.121Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2117,6 +2390,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/bc/0bc9c0ec1cf83ab2ec6e6f38667d167349b950fff6dd2086b79bd360eeca/sentence_transformers-5.2.2.tar.gz", hash = "sha256:7033ee0a24bc04c664fd490abf2ef194d387b3a58a97adcc528783ff505159fa", size = 381607, upload-time = "2026-01-27T11:11:02.658Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/21/7e925890636791386e81b52878134f114d63072e79fffe14cdcc5e7a5e6a/sentence_transformers-5.2.2-py3-none-any.whl", hash = "sha256:280ac54bffb84c110726b4d8848ba7b7c60813b9034547f8aea6e9a345cd1c23", size = 494106, upload-time = "2026-01-27T11:11:00.983Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515, upload-time = "2025-08-12T07:00:51.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/15/46afbab00733d81788b64be430ca1b93011bb9388527958e26cc31832de5/sentencepiece-0.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6356d0986b8b8dc351b943150fcd81a1c6e6e4d439772e8584c64230e58ca987", size = 1942560, upload-time = "2025-08-12T06:59:25.82Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/7c01b8ef98a0567e9d84a4e7a910f8e7074fcbf398a5cd76f93f4b9316f9/sentencepiece-0.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f8ba89a3acb3dc1ae90f65ec1894b0b9596fdb98ab003ff38e058f898b39bc7", size = 1325385, upload-time = "2025-08-12T06:59:27.722Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/88/2b41e07bd24f33dcf2f18ec3b74247aa4af3526bad8907b8727ea3caba03/sentencepiece-0.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:02593eca45440ef39247cee8c47322a34bdcc1d8ae83ad28ba5a899a2cf8d79a", size = 1253319, upload-time = "2025-08-12T06:59:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/54/38a1af0c6210a3c6f95aa46d23d6640636d020fba7135cd0d9a84ada05a7/sentencepiece-0.2.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a0d15781a171d188b661ae4bde1d998c303f6bd8621498c50c671bd45a4798e", size = 1316162, upload-time = "2025-08-12T06:59:30.914Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/66/fb191403ade791ad2c3c1e72fe8413e63781b08cfa3aa4c9dfc536d6e795/sentencepiece-0.2.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f5a3e0d9f445ed9d66c0fec47d4b23d12cfc858b407a03c194c1b26c2ac2a63", size = 1387785, upload-time = "2025-08-12T06:59:32.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2d/3bd9b08e70067b2124518b308db6a84a4f8901cc8a4317e2e4288cdd9b4d/sentencepiece-0.2.1-cp311-cp311-win32.whl", hash = "sha256:6d297a1748d429ba8534eebe5535448d78b8acc32d00a29b49acf28102eeb094", size = 999555, upload-time = "2025-08-12T06:59:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b8/f709977f5fda195ae1ea24f24e7c581163b6f142b1005bc3d0bbfe4d7082/sentencepiece-0.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:82d9ead6591015f009cb1be1cb1c015d5e6f04046dbb8c9588b931e869a29728", size = 1054617, upload-time = "2025-08-12T06:59:36.461Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/40/a1fc23be23067da0f703709797b464e8a30a1c78cc8a687120cd58d4d509/sentencepiece-0.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:39f8651bd10974eafb9834ce30d9bcf5b73e1fc798a7f7d2528f9820ca86e119", size = 1033877, upload-time = "2025-08-12T06:59:38.391Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/be/32ce495aa1d0e0c323dcb1ba87096037358edee539cac5baf8755a6bd396/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57cae326c8727de58c85977b175af132a7138d84c764635d7e71bbee7e774133", size = 1943152, upload-time = "2025-08-12T06:59:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7e/ff23008899a58678e98c6ff592bf4d368eee5a71af96d0df6b38a039dd4f/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dd39a3c4d6493db3cdca7e8cc68c6b633f0d4195495cbadfcf5af8a22d05a6", size = 1325651, upload-time = "2025-08-12T06:59:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/19/84/42eb3ce4796777a1b5d3699dfd4dca85113e68b637f194a6c8d786f16a04/sentencepiece-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9381351182ff9888cc80e41c632e7e274b106f450de33d67a9e8f6043da6f76", size = 1253645, upload-time = "2025-08-12T06:59:42.903Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fa/d3d5ebcba3cb9e6d3775a096251860c41a6bc53a1b9461151df83fe93255/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f955df238021bf11f0fc37cdb54fd5e5b5f7fd30ecc3d93fb48b6815437167", size = 1316273, upload-time = "2025-08-12T06:59:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/04/88/14f2f4a2b922d8b39be45bf63d79e6cd3a9b2f248b2fcb98a69b12af12f5/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cdfecef430d985f1c2bcbfff3defd1d95dae876fbd0173376012d2d7d24044b", size = 1387881, upload-time = "2025-08-12T06:59:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b8/903e5ccb77b4ef140605d5d71b4f9e0ad95d456d6184688073ed11712809/sentencepiece-0.2.1-cp312-cp312-win32.whl", hash = "sha256:a483fd29a34c3e34c39ac5556b0a90942bec253d260235729e50976f5dba1068", size = 999540, upload-time = "2025-08-12T06:59:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/92df5673c067148c2545b1bfe49adfd775bcc3a169a047f5a0e6575ddaca/sentencepiece-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4cdc7c36234fda305e85c32949c5211faaf8dd886096c7cea289ddc12a2d02de", size = 1054671, upload-time = "2025-08-12T06:59:49.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/02/c5e3bc518655d714622bec87d83db9cdba1cd0619a4a04e2109751c4f47f/sentencepiece-0.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:daeb5e9e9fcad012324807856113708614d534f596d5008638eb9b40112cd9e4", size = 1033923, upload-time = "2025-08-12T06:59:51.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150, upload-time = "2025-08-12T06:59:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651, upload-time = "2025-08-12T06:59:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641, upload-time = "2025-08-12T06:59:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271, upload-time = "2025-08-12T06:59:58.109Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882, upload-time = "2025-08-12T07:00:00.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541, upload-time = "2025-08-12T07:00:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669, upload-time = "2025-08-12T07:00:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922, upload-time = "2025-08-12T07:00:06.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052, upload-time = "2025-08-12T07:00:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408, upload-time = "2025-08-12T07:00:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857, upload-time = "2025-08-12T07:00:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722, upload-time = "2025-08-12T07:00:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452, upload-time = "2025-08-12T07:00:15.088Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501, upload-time = "2025-08-12T07:00:16.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555, upload-time = "2025-08-12T07:00:18.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042, upload-time = "2025-08-12T07:00:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/89eb8b2052f720a612478baf11c8227dcf1dc28cd4ea4c0c19506b5af2a2/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5d0350b686c320068702116276cfb26c066dc7e65cfef173980b11bb4d606719", size = 1943147, upload-time = "2025-08-12T07:00:21.809Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0b/a1432bc87f97c2ace36386ca23e8bd3b91fb40581b5e6148d24b24186419/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c7f54a31cde6fa5cb030370566f68152a742f433f8d2be458463d06c208aef33", size = 1325624, upload-time = "2025-08-12T07:00:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/99/bbe054ebb5a5039457c590e0a4156ed073fb0fe9ce4f7523404dd5b37463/sentencepiece-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c83b85ab2d6576607f31df77ff86f28182be4a8de6d175d2c33ca609925f5da1", size = 1253670, upload-time = "2025-08-12T07:00:24.69Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ad/d5c7075f701bd97971d7c2ac2904f227566f51ef0838dfbdfdccb58cd212/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1855f57db07b51fb51ed6c9c452f570624d2b169b36f0f79ef71a6e6c618cd8b", size = 1316247, upload-time = "2025-08-12T07:00:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/03/35fbe5f3d9a7435eebd0b473e09584bd3cc354ce118b960445b060d33781/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01e6912125cb45d3792f530a4d38f8e21bf884d6b4d4ade1b2de5cf7a8d2a52b", size = 1387894, upload-time = "2025-08-12T07:00:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/aa/956ef729aafb6c8f9c443104c9636489093bb5c61d6b90fc27aa1a865574/sentencepiece-0.2.1-cp314-cp314-win32.whl", hash = "sha256:c415c9de1447e0a74ae3fdb2e52f967cb544113a3a5ce3a194df185cbc1f962f", size = 1096698, upload-time = "2025-08-12T07:00:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/fe400d8836952cc535c81a0ce47dc6875160e5fedb71d2d9ff0e9894c2a6/sentencepiece-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:881b2e44b14fc19feade3cbed314be37de639fc415375cefaa5bc81a4be137fd", size = 1155115, upload-time = "2025-08-12T07:00:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/047921cf70f36c7b6b6390876b2399b3633ab73b8d0cb857e5a964238941/sentencepiece-0.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2005242a16d2dc3ac5fe18aa7667549134d37854823df4c4db244752453b78a8", size = 1133890, upload-time = "2025-08-12T07:00:34.763Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/5b414b9fae6255b5fb1e22e2ed3dc3a72d3a694e5703910e640ac78346bb/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a19adcec27c524cb7069a1c741060add95f942d1cbf7ad0d104dffa0a7d28a2b", size = 1946081, upload-time = "2025-08-12T07:00:36.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/eb/7a5682bb25824db8545f8e5662e7f3e32d72a508fdce086029d89695106b/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e37e4b4c4a11662b5db521def4e44d4d30ae69a1743241412a93ae40fdcab4bb", size = 1327406, upload-time = "2025-08-12T07:00:38.669Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b0/811dae8fb9f2784e138785d481469788f2e0d0c109c5737372454415f55f/sentencepiece-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:477c81505db072b3ab627e7eab972ea1025331bd3a92bacbf798df2b75ea86ec", size = 1254846, upload-time = "2025-08-12T07:00:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/23/195b2e7ec85ebb6a547969f60b723c7aca5a75800ece6cc3f41da872d14e/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:010f025a544ef770bb395091d57cb94deb9652d8972e0d09f71d85d5a0816c8c", size = 1315721, upload-time = "2025-08-12T07:00:42.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/553dbe4178b5f23eb28e59393dddd64186178b56b81d9b8d5c3ff1c28395/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:733e59ff1794d26db706cd41fc2d7ca5f6c64a820709cb801dc0ea31780d64ab", size = 1387458, upload-time = "2025-08-12T07:00:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7c/08ff0012507297a4dd74a5420fdc0eb9e3e80f4e88cab1538d7f28db303d/sentencepiece-0.2.1-cp314-cp314t-win32.whl", hash = "sha256:d3233770f78e637dc8b1fda2cd7c3b99ec77e7505041934188a4e7fe751de3b0", size = 1099765, upload-time = "2025-08-12T07:00:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d5/2a69e1ce15881beb9ddfc7e3f998322f5cedcd5e4d244cb74dade9441663/sentencepiece-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e4366c97b68218fd30ea72d70c525e6e78a6c0a88650f57ac4c43c63b234a9d", size = 1157807, upload-time = "2025-08-12T07:00:47.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/54f611fcfc2d1c46cbe3ec4169780b2cfa7cf63708ef2b71611136db7513/sentencepiece-0.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:105e36e75cbac1292642045458e8da677b2342dcd33df503e640f0b457cb6751", size = 1136264, upload-time = "2025-08-12T07:00:49.485Z" },
 ]
 
 [[package]]
@@ -2293,7 +2622,7 @@ wheels = [
 
 [[package]]
 name = "stanza"
-version = "1.11.0"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "emoji" },
@@ -2304,9 +2633,9 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/e5/acd22862a75f424d98bb690fec9ab292da6e797cab367fa8fa451c547637/stanza-1.11.0.tar.gz", hash = "sha256:42ba9d4752e74c4e1e6fc2ca96e98bb8fa194049782cc35fde2a5118fd5f75ab", size = 1484551, upload-time = "2025-10-05T06:44:03.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/d3/1e849c2fd5c31250534407205dcf10265defce35795c7fc9846d3b689848/stanza-1.10.1.tar.gz", hash = "sha256:f1b283021323ef9273fb1a751a194c0d568e373a2a11b933e2f4b600322406b2", size = 901628, upload-time = "2024-12-24T06:07:27.09Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/47/c6f8dd24ca100f6c260209b27be4d2e0ae68f13d4b2b4b1b343876c9e765/stanza-1.11.0-py3-none-any.whl", hash = "sha256:3a0bcf24830e32e88f6d0cff1e757661e53ed1b60149fa7f72211d61c6dab063", size = 1706081, upload-time = "2025-10-05T06:43:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f6/c50d0ee85e40687a81a95d90d426938d0d83ac0683efa2b87fa4110b665c/stanza-1.10.1-py3-none-any.whl", hash = "sha256:d0ebc22c7e7a201077e0ed88d2450e654acadb4ea0d8584d5a5eb2ae1e65c060", size = 1112060, upload-time = "2024-12-24T06:07:22.898Z" },
 ]
 
 [[package]]
@@ -2328,9 +2657,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "uvicorn" },
 ]
 
@@ -2360,13 +2691,18 @@ topic = [
     { name = "hdbscan" },
     { name = "umap-learn" },
 ]
+translation = [
+    { name = "argostranslate" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.116.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pyjwt", specifier = ">=2.9.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
@@ -2394,6 +2730,7 @@ topic = [
     { name = "hdbscan", specifier = ">=0.8.33" },
     { name = "umap-learn", specifier = ">=0.5.7" },
 ]
+translation = [{ name = "argostranslate", specifier = ">=1.9.6" }]
 
 [[package]]
 name = "sympy"

--- a/web/src/demo_data/re_zero_summary.json
+++ b/web/src/demo_data/re_zero_summary.json
@@ -1,0 +1,15 @@
+{
+  "series_code": "n2267be",
+  "fetched_at_utc": "2026-02-10T05:45:24.797646+00:00",
+  "chapter_count": 762,
+  "chapter_numbers_min": 1,
+  "chapter_numbers_max": 762,
+  "chapter_chars_total": 9175223,
+  "chapter_chars_min": 0,
+  "chapter_chars_max": 52909,
+  "chapter_chars_mean": 12040.98,
+  "chapter_chars_median": 11643.5,
+  "chapters_over_5000_chars": 724,
+  "chapters_over_10000_chars": 530,
+  "chapters_under_1000_chars": 25
+}

--- a/web/src/offline_demo.tsx
+++ b/web/src/offline_demo.tsx
@@ -3,22 +3,15 @@ import { useMemo, useState, type ReactElement } from "react";
 import type {
   DashboardArcPointResponse,
   DashboardGraphResponse,
-  DashboardOverviewResponse,
   DashboardThemeHeatmapCellResponse,
   DashboardTimelineLaneResponse,
 } from "./types";
 import { useThemeMode } from "./theme";
+import reZeroSummary from "./demo_data/re_zero_summary.json";
 
-const overview: DashboardOverviewResponse = {
-  title: "Story Intelligence Overview",
-  macro_thesis:
-    "A forged archive triggers civic conflict, but evidence and witness memory restore shared truth.",
-  confidence_floor: 0.74,
-  quality_passed: true,
-  events_count: 7,
-  beats_count: 7,
-  themes_count: 4,
-};
+const overviewTitle = "Re:Zero Batch Summary";
+const overviewNote =
+  "Batch crawl stats from the Re:Zero chapter set (counts only, no text).";
 
 const timeline: DashboardTimelineLaneResponse[] = [
   {
@@ -158,26 +151,24 @@ export const OfflineDemoStudio = (): ReactElement => {
       </section>
 
       <section className="card">
-        <h2>{overview.title}</h2>
-        <p className="status">{overview.macro_thesis}</p>
+        <h2>{overviewTitle}</h2>
+        <p className="status">{overviewNote}</p>
         <div className="kpi-grid">
           <article className="kpi-card">
-            <strong>Confidence floor</strong>
-            <div>{overview.confidence_floor.toFixed(2)}</div>
+            <strong>Chapters</strong>
+            <div>{reZeroSummary.chapter_count.toLocaleString()}</div>
           </article>
           <article className="kpi-card">
-            <strong>Quality gate</strong>
-            <div>{overview.quality_passed ? "pass" : "warn"}</div>
+            <strong>Total chars</strong>
+            <div>{reZeroSummary.chapter_chars_total.toLocaleString()}</div>
           </article>
           <article className="kpi-card">
-            <strong>Events / Beats</strong>
-            <div>
-              {overview.events_count} / {overview.beats_count}
-            </div>
+            <strong>Median chars</strong>
+            <div>{reZeroSummary.chapter_chars_median.toLocaleString()}</div>
           </article>
           <article className="kpi-card">
-            <strong>Themes</strong>
-            <div>{overview.themes_count}</div>
+            <strong>Chapters ≥ 10k</strong>
+            <div>{reZeroSummary.chapters_over_10000_chars.toLocaleString()}</div>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Adds Keycloak OIDC auth validation, a batch pipeline runner with timing summaries, and a Re:Zero-derived offline demo summary. Updates docs, ADRs, and tests to reflect the new batch pipeline, translation fallback, and Keycloak mode.

## Linked Issues

- https://github.com/ringxworld/story_generator/issues/128

## Full Mode (Larger/Riskier Change)

### Motivation / Context

We need reliable end-to-end batch runs with timing capture and translation fallback, plus a supported Keycloak auth mode. The offline demo should reflect real story-scale metrics.

### What Changed

- Added: Keycloak OIDC auth validation with JWKS discovery/inline support.
- Added: Batch pipeline CLI with per-chapter summaries and timing totals.
- Added: ADRs + lessons learned, and Re:Zero crawl stats in offline demo.
- Changed: Translation retry handling and optional offline translation support.

### Tradeoffs and Risks

- Performance impacts: Batch runs still depend on translation provider throughput.
- Behavior changes: Local auth endpoints return 501 in Keycloak mode.
- Edge cases that still exist: Chapters with very low-quality translation output.
- Things deliberately left out: No raw third-party text committed to the repo.

### How This Was Tested

- Unit tests added or updated: keycloak auth tests, batch pipeline tests.
- Manual test cases run: none.
- Inputs used to validate behavior: small synthetic chapters.
- Not tested (if any): Full Re:Zero batch run in CI.

### Follow-ups / Future Work (Optional)

- Add translation quality scoring per chapter.
- Add regression baselines for batch runtime.
