### PR TITLE
feat: Re:Zero end-to-end pipeline - batch runner dashboard generation and graph edge filtering

### DIFF
--- a/src/story_gen/core/dashboard_views.py
+++ b/src/story_gen/core/dashboard_views.py
@@ -951,19 +951,28 @@ def _build_graph(
             )
         )
 
-    theme_ids = [theme.theme_id for theme in document.theme_signals]
-    beat_ids = [beat.beat_id for beat in document.story_beats]
-    # TODO(#9): Replace dense theme->beat linking with evidence-driven graph edges.
-    for theme_id in theme_ids:
-        for beat_id in beat_ids:
-            edges.append(
-                GraphEdge(
-                    source=theme_id,
-                    target=beat_id,
-                    relation="expressed_in",
-                    weight=0.5,
+    # Build evidence-driven edges: connect themes to beats based on shared evidence segments.
+    theme_segments: dict[str, set[str]] = {
+        theme.theme_id: set(theme.evidence_segment_ids)
+        for theme in document.theme_signals
+    }
+    beat_segments: dict[str, set[str]] = {
+        beat.beat_id: set(beat.evidence_segment_ids) for beat in document.story_beats
+    }
+    for theme_id, theme_segment_set in theme_segments.items():
+        for beat_id, beat_segment_set in beat_segments.items():
+            overlap = theme_segment_set & beat_segment_set
+            if overlap:
+                # Weight based on normalized overlap: how much of the beat's evidence contains this theme.
+                weight = round(len(overlap) / max(len(beat_segment_set), 1) * 0.9 + 0.1, 2)
+                edges.append(
+                    GraphEdge(
+                        source=theme_id,
+                        target=beat_id,
+                        relation="expressed_in",
+                        weight=weight,
+                    )
                 )
-            )
     return _layout_graph_nodes(nodes), edges
 
 

--- a/src/story_gen/core/dashboard_views.py
+++ b/src/story_gen/core/dashboard_views.py
@@ -953,8 +953,7 @@ def _build_graph(
 
     # Build evidence-driven edges: connect themes to beats based on shared evidence segments.
     theme_segments: dict[str, set[str]] = {
-        theme.theme_id: set(theme.evidence_segment_ids)
-        for theme in document.theme_signals
+        theme.theme_id: set(theme.evidence_segment_ids) for theme in document.theme_signals
     }
     beat_segments: dict[str, set[str]] = {
         beat.beat_id: set(beat.evidence_segment_ids) for beat in document.story_beats


### PR DESCRIPTION
## Summary
Adds Re:Zero batch pipeline dashboard generation and evidence-driven graph edge filtering in dashboard views.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/128
- https://github.com/ringxworld/story_generator/issues/9

## Full Mode (Larger/Riskier Change)
### Motivation / Context
Batch outputs needed dashboard-ready summaries, and graph rendering needed to stop producing dense all-to-all edges that obscured narrative evidence relationships.

### What Changed
- Added batch-run dashboard payload generation in `src/story_gen/cli/pipeline_batch.py`.
- Added helper parsing and chapter summary projection logic for dashboard metrics.
- Replaced dense theme-to-beat graph linking with evidence-overlap filtering in `src/story_gen/core/dashboard_views.py`.
- Added tests for evidence-driven graph edges.

### Tradeoffs and Risks
- Behavior changes in graph edge density may alter existing dashboard visuals.
- Batch dashboard payload generation increases output surface area and requires stronger contract maintenance.

### How This Was Tested
- CI suite for this PR (`quality`, `frontend`, `pages`, `native`, `docker`).
- Added/updated tests around graph edge behavior.
- Existing dashboard export tests run in CI to verify deterministic outputs.