### PR TITLE
Add sentence/dialogue extraction details to analysis drilldown

### DIFF
--- a/docs/adr/0033-sentence-and-dialogue-extraction-details.md
+++ b/docs/adr/0033-sentence-and-dialogue-extraction-details.md
@@ -1,0 +1,34 @@
+# 0033 Sentence and Dialogue Extraction Details
+
+## Problem
+
+The current story analysis pipeline extracts events and entities, but it does
+not expose structured sentence-level dialogue details. That gap makes it hard
+to inspect speaker consistency, internal thought signals, and narrative mode
+balance across analyzed segments.
+
+## Non-goals
+
+- Replacing the existing event/entity extraction stage.
+- Introducing non-deterministic model dependencies.
+- Redesigning dashboard architecture or storage adapters.
+
+## Public API
+
+- Dashboard drilldown payload now includes additive extraction detail items:
+  - `extraction_detail` for narrative balance summary.
+  - `extraction_speaker` for attributed dialogue speaker rollups.
+  - `extraction_monologue` for internal monologue signals.
+- No existing endpoint is removed or renamed.
+
+## Invariants
+
+- Extraction remains deterministic for identical input text.
+- Unknown speaker attribution falls back to `unknown` instead of failing.
+- Drilldown entries always include evidence segment identifiers.
+- Existing story analysis schema version remains `story_analysis.v1`.
+
+## Test plan
+
+- `uv run pytest tests/test_dialogue_extraction.py`
+- `uv run pytest tests/test_story_analysis_pipeline.py`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ Latest ADR:
 - `0030-openapi-snapshot-and-hosted-api-reference.md`
 - `0031-keycloak-oidc-auth.md`
 - `0032-batch-pipeline-re-zero-benchmark.md`
+- `0033-sentence-and-dialogue-extraction-details.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This file defines the stable shape of the repository and import boundaries.
 - `src/story_gen/core/`
   - Internal pure business logic, domain orchestration, and deterministic evaluation/extraction.
   - Story intelligence pipeline stages (`story_schema`, ingestion, translation, extraction,
-    beats/themes/timeline/insights, quality gate, dashboard projections).
+    dialogue-detail extraction, beats/themes/timeline/insights, quality gate, dashboard projections).
 - `src/story_gen/adapters/`
   - Side effects: filesystem, network, subprocesses, model loading.
   - Local persistence adapters (for example SQLite story/feature/essay storage).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - 0030 OpenAPI Snapshot and Hosted API Reference: adr/0030-openapi-snapshot-and-hosted-api-reference.md
       - 0031 Keycloak OIDC Auth: adr/0031-keycloak-oidc-auth.md
       - 0032 Batch Pipeline Re:Zero Benchmark: adr/0032-batch-pipeline-re-zero-benchmark.md
+      - 0033 Sentence and Dialogue Extraction Details: adr/0033-sentence-and-dialogue-extraction-details.md
   - Guides:
       - Dependency Charts: dependency_charts.md
       - Reference Pipeline: reference_pipeline.md

--- a/src/story_gen/core/dialogue_extraction.py
+++ b/src/story_gen/core/dialogue_extraction.py
@@ -1,0 +1,275 @@
+"""Deterministic dialogue and narrative-detail extraction helpers."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Literal
+
+from story_gen.core.story_schema import RawSegment
+
+NarrativeMode = Literal["dialogue", "action", "exposition", "monologue"]
+
+_WORD_PATTERN = re.compile(r"[A-Za-z']+")
+_TRANSCRIPT_LINE = re.compile(r"^\s*(?P<speaker>[A-Z][A-Za-z0-9_. -]{0,40}):\s*(?P<utterance>.+)$")
+_QUOTED_UTTERANCE = re.compile(r'"(?P<utterance>[^"\n]{1,800})"')
+_SPEAKER_BEFORE_QUOTE = re.compile(
+    r"(?P<speaker>[A-Z][A-Za-z0-9_-]{1,40})[^.!?\n]{0,90}\b(?:said|asked|whispered|"
+    r"replied|murmured|shouted|cried|yelled|told|answered)\s*$",
+    flags=re.IGNORECASE,
+)
+_SPEAKER_AFTER_QUOTE = re.compile(
+    r"^\s*[,;-]?\s*(?:said|asked|whispered|replied|murmured|shouted|cried|yelled|"
+    r"told|answered)\s+(?P<speaker>[A-Z][A-Za-z0-9_-]{1,40})",
+    flags=re.IGNORECASE,
+)
+_FIRST_PERSON_PATTERN = re.compile(r"\b(i|me|my|mine|myself)\b", flags=re.IGNORECASE)
+_THOUGHT_VERB_PATTERN = re.compile(
+    r"\b(think|thought|wonder|wondered|remember|remembered|realize|realized|"
+    r"wish|wished|fear|feared|hope|hoped|decide|decided)\b",
+    flags=re.IGNORECASE,
+)
+_ACTION_KEYWORDS = {
+    "run",
+    "ran",
+    "rush",
+    "rushed",
+    "fight",
+    "fought",
+    "grab",
+    "grabbed",
+    "strike",
+    "struck",
+    "attack",
+    "attacked",
+    "chase",
+    "chased",
+    "jump",
+    "jumped",
+    "climb",
+    "climbed",
+    "confront",
+    "confronts",
+    "confronted",
+    "escape",
+    "escaped",
+    "sprint",
+    "sprinted",
+}
+_EXPOSITION_KEYWORDS = {
+    "because",
+    "therefore",
+    "history",
+    "tradition",
+    "explains",
+    "explained",
+    "describes",
+    "described",
+    "had",
+    "was",
+    "were",
+    "known",
+    "believed",
+    "context",
+    "background",
+}
+
+
+@dataclass(frozen=True)
+class DialogueTurn:
+    """One extracted dialogue turn with heuristic speaker attribution."""
+
+    segment_id: str
+    speaker: str
+    utterance: str
+    attribution_method: str
+
+
+@dataclass(frozen=True)
+class InternalMonologueSignal:
+    """One internal-thought signal discovered in a segment."""
+
+    segment_id: str
+    excerpt: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class NarrativeBalance:
+    """Aggregate narrative-mode ratios across analyzed segments."""
+
+    dialogue_ratio: float
+    action_ratio: float
+    exposition_ratio: float
+    monologue_ratio: float
+
+
+@dataclass(frozen=True)
+class DialogueExtractionDetails:
+    """Combined extraction details used by dashboard and diagnostics surfaces."""
+
+    segment_ids: list[str]
+    dialogue_turns: list[DialogueTurn]
+    internal_monologues: list[InternalMonologueSignal]
+    dominant_mode_by_segment: dict[str, NarrativeMode]
+    narrative_balance: NarrativeBalance
+
+
+def extract_dialogue_details(
+    *,
+    segments: list[RawSegment],
+    known_character_names: list[str] | None = None,
+) -> DialogueExtractionDetails:
+    """Extract dialogue turns, internal monologue, and narrative mode balance."""
+    known_names = {name.strip().lower() for name in (known_character_names or []) if name.strip()}
+    segment_ids: list[str] = []
+    dialogue_turns: list[DialogueTurn] = []
+    internal_monologues: list[InternalMonologueSignal] = []
+    mode_by_segment: dict[str, NarrativeMode] = {}
+    mode_counts: Counter[NarrativeMode] = Counter()
+
+    for segment in segments:
+        text = (segment.translated_text or segment.normalized_text).strip()
+        if not text:
+            continue
+        segment_ids.append(segment.segment_id)
+
+        turns = _extract_turns(segment_id=segment.segment_id, text=text, known_names=known_names)
+        dialogue_turns.extend(turns)
+        monologue = _extract_internal_monologue(segment_id=segment.segment_id, text=text)
+        if monologue is not None:
+            internal_monologues.append(monologue)
+        dominant_mode = _dominant_mode(text=text, turns=turns, has_monologue=monologue is not None)
+        mode_by_segment[segment.segment_id] = dominant_mode
+        mode_counts[dominant_mode] += 1
+
+    total = max(len(segment_ids), 1)
+    details = DialogueExtractionDetails(
+        segment_ids=segment_ids,
+        dialogue_turns=dialogue_turns,
+        internal_monologues=internal_monologues,
+        dominant_mode_by_segment=mode_by_segment,
+        narrative_balance=NarrativeBalance(
+            dialogue_ratio=round(mode_counts["dialogue"] / total, 4),
+            action_ratio=round(mode_counts["action"] / total, 4),
+            exposition_ratio=round(mode_counts["exposition"] / total, 4),
+            monologue_ratio=round(mode_counts["monologue"] / total, 4),
+        ),
+    )
+    return details
+
+
+def _extract_turns(
+    *,
+    segment_id: str,
+    text: str,
+    known_names: set[str],
+) -> list[DialogueTurn]:
+    transcript_match = _TRANSCRIPT_LINE.match(text)
+    if transcript_match:
+        speaker = _normalize_speaker(transcript_match.group("speaker"), known_names=known_names)
+        utterance = (transcript_match.group("utterance") or "").strip()
+        if utterance:
+            return [
+                DialogueTurn(
+                    segment_id=segment_id,
+                    speaker=speaker,
+                    utterance=utterance,
+                    attribution_method="transcript_prefix",
+                )
+            ]
+
+    turns: list[DialogueTurn] = []
+    for match in _QUOTED_UTTERANCE.finditer(text):
+        utterance = (match.group("utterance") or "").strip()
+        if not utterance:
+            continue
+        prefix = text[: match.start()]
+        suffix = text[match.end() :]
+        speaker, method = _resolve_speaker(prefix=prefix, suffix=suffix, known_names=known_names)
+        turns.append(
+            DialogueTurn(
+                segment_id=segment_id,
+                speaker=speaker,
+                utterance=utterance,
+                attribution_method=method,
+            )
+        )
+    return turns
+
+
+def _resolve_speaker(
+    *,
+    prefix: str,
+    suffix: str,
+    known_names: set[str],
+) -> tuple[str, str]:
+    before_match = _SPEAKER_BEFORE_QUOTE.search(prefix)
+    if before_match:
+        speaker = _normalize_speaker(before_match.group("speaker"), known_names=known_names)
+        return speaker, "narrative_before_quote"
+
+    after_match = _SPEAKER_AFTER_QUOTE.search(suffix)
+    if after_match:
+        speaker = _normalize_speaker(after_match.group("speaker"), known_names=known_names)
+        return speaker, "narrative_after_quote"
+
+    return "unknown", "unknown"
+
+
+def _normalize_speaker(raw: str | None, *, known_names: set[str]) -> str:
+    value = (raw or "").strip().lower()
+    if not value:
+        return "unknown"
+    if known_names and value not in known_names:
+        return "unknown"
+    return value
+
+
+def _extract_internal_monologue(*, segment_id: str, text: str) -> InternalMonologueSignal | None:
+    has_first_person = bool(_FIRST_PERSON_PATTERN.search(text))
+    has_thought_verb = bool(_THOUGHT_VERB_PATTERN.search(text))
+    if not has_first_person and not has_thought_verb:
+        return None
+    confidence = 0.45
+    if has_first_person:
+        confidence += 0.25
+    if has_thought_verb:
+        confidence += 0.25
+    if "?" in text:
+        confidence += 0.05
+    excerpt = text.strip()
+    if len(excerpt) > 140:
+        excerpt = f"{excerpt[:137]}..."
+    return InternalMonologueSignal(
+        segment_id=segment_id,
+        excerpt=excerpt,
+        confidence=round(min(confidence, 0.95), 3),
+    )
+
+
+def _dominant_mode(
+    *,
+    text: str,
+    turns: list[DialogueTurn],
+    has_monologue: bool,
+) -> NarrativeMode:
+    tokens = [token.lower() for token in _WORD_PATTERN.findall(text)]
+    token_total = max(len(tokens), 1)
+    action_hits = sum(1 for token in tokens if token in _ACTION_KEYWORDS)
+    exposition_hits = sum(1 for token in tokens if token in _EXPOSITION_KEYWORDS)
+
+    scores: dict[NarrativeMode, float] = {
+        "dialogue": 0.0,
+        "action": action_hits / token_total,
+        "exposition": 0.1 + (exposition_hits / token_total),
+        "monologue": 0.0,
+    }
+    if turns:
+        scores["dialogue"] = 1.0 + min(0.6, len(turns) * 0.2)
+    if has_monologue:
+        scores["monologue"] = 1.05
+
+    precedence: list[NarrativeMode] = ["monologue", "dialogue", "action", "exposition"]
+    return max(precedence, key=lambda mode: (scores[mode], -precedence.index(mode)))

--- a/tests/test_dialogue_extraction.py
+++ b/tests/test_dialogue_extraction.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from story_gen.core.dialogue_extraction import extract_dialogue_details
+from story_gen.core.story_schema import RawSegment
+
+
+def _segment(*, segment_id: str, text: str) -> RawSegment:
+    return RawSegment(
+        segment_id=segment_id,
+        source_type="text",
+        original_text=text,
+        normalized_text=text,
+        language_code="en",
+        translated_text=text,
+        segment_index=1,
+        char_start=0,
+        char_end=max(1, len(text)),
+    )
+
+
+def test_extract_dialogue_details_parses_turns_and_internal_monologue() -> None:
+    segments = [
+        _segment(segment_id="seg001", text="Rhea: We move now."),
+        _segment(segment_id="seg002", text='"Hold the gate," said Rhea.'),
+        _segment(
+            segment_id="seg003",
+            text="I thought we were finished, but I refused to surrender.",
+        ),
+    ]
+
+    details = extract_dialogue_details(segments=segments, known_character_names=["rhea"])
+
+    assert len(details.dialogue_turns) == 2
+    assert details.dialogue_turns[0].speaker == "rhea"
+    assert details.dialogue_turns[0].attribution_method == "transcript_prefix"
+    assert details.dialogue_turns[1].speaker == "rhea"
+    assert details.dialogue_turns[1].attribution_method == "narrative_after_quote"
+    assert details.internal_monologues
+    assert details.internal_monologues[0].segment_id == "seg003"
+    assert details.dominant_mode_by_segment["seg001"] == "dialogue"
+    assert details.dominant_mode_by_segment["seg003"] == "monologue"
+    assert details.narrative_balance.dialogue_ratio > 0
+    assert details.narrative_balance.monologue_ratio > 0
+
+
+def test_extract_dialogue_details_unknown_speaker_and_no_cues() -> None:
+    segments = [
+        _segment(segment_id="seg010", text='"Retreat now," said Commander.'),
+        _segment(
+            segment_id="seg011",
+            text="The archive was founded long ago and was known for rigid customs.",
+        ),
+    ]
+
+    details = extract_dialogue_details(segments=segments, known_character_names=["rhea"])
+
+    assert details.dialogue_turns
+    assert details.dialogue_turns[0].speaker == "unknown"
+    assert details.internal_monologues == []
+    assert details.dominant_mode_by_segment["seg011"] == "exposition"
+
+
+def test_extract_dialogue_details_handles_malformed_quotes_without_crashing() -> None:
+    segments = [
+        _segment(
+            segment_id="seg020",
+            text='Rhea said "We should move quickly before dawn and then paused abruptly',
+        ),
+        _segment(
+            segment_id="seg021",
+            text="They rushed down the corridor and jumped over shattered stone.",
+        ),
+    ]
+
+    details = extract_dialogue_details(segments=segments, known_character_names=["rhea"])
+
+    assert details.dialogue_turns == []
+    assert details.dominant_mode_by_segment["seg020"] in {"exposition", "action"}
+    assert details.dominant_mode_by_segment["seg021"] == "action"

--- a/tests/test_story_analysis_pipeline.py
+++ b/tests/test_story_analysis_pipeline.py
@@ -164,3 +164,25 @@ def test_pipeline_drilldown_includes_theme_arc_conflict_and_emotion() -> None:
     assert "conflict" in item_types
     assert "emotion" in item_types
     assert all(item.evidence_segment_ids for item in drilldown_items)
+
+
+def test_pipeline_drilldown_includes_extraction_detail_items() -> None:
+    source_text = (
+        'Rhea said, "We cannot turn back." '
+        '"Then hold the line," said Rhea. '
+        "I thought we were done, but I kept moving."
+    )
+    result = run_story_analysis(story_id="story-extraction-details", source_text=source_text)
+
+    item_types = {item.item_type for item in result.dashboard.drilldown.values()}
+    assert "extraction_detail" in item_types
+    assert "extraction_monologue" in item_types
+    assert "extraction_speaker" in item_types
+
+    speaker_items = [
+        item
+        for item in result.dashboard.drilldown.values()
+        if item.item_type == "extraction_speaker"
+    ]
+    assert speaker_items
+    assert all(item.evidence_segment_ids for item in speaker_items)


### PR DESCRIPTION
## Summary
Adds a deterministic sentence/dialogue extraction slice for the story analysis pipeline and surfaces it through dashboard drilldown payloads.

## Linked Issues
- https://github.com/ringxworld/story_generator/issues/203

## Compact Mode (Small/Low-Risk Change)
### Change Notes
- Added `core.dialogue_extraction` for dialogue turn parsing, speaker attribution heuristics, internal monologue detection, and narrative-mode balance classification.
- Integrated extraction details into `core.dashboard_views` drilldown output as additive item types: `extraction_detail`, `extraction_speaker`, and `extraction_monologue`.
- Added ADR `0033` and docs navigation/index updates.
- Added regression tests for extraction edge cases and pipeline drilldown integration.

### Validation
- `uv lock --check`
- `uv run python tools/check_imports.py`
- `uv run ruff check src tests tools`
- `uv run ruff format --check src tests tools`
- `uv run mypy`
- `uv run pytest`
- `uv run mkdocs build --strict`